### PR TITLE
Fix can not move a cell to the end correctly

### DIFF
--- a/RealmClear/ViewController.swift
+++ b/RealmClear/ViewController.swift
@@ -176,11 +176,11 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
 
     func longPressGestureRecognized(recognizer: UILongPressGestureRecognizer) {
         let location = recognizer.locationInView(tableView)
-        let indexPath = tableView.indexPathForRowAtPoint(location)
+        let indexPath = tableView.indexPathForRowAtPoint(location) ?? NSIndexPath(forRow: items.count - 1, inSection: 0)
         switch recognizer.state {
         case .Possible: break
         case .Began:
-            guard let indexPath = indexPath, cell = tableView.cellForRowAtIndexPath(indexPath) else { break }
+            guard let cell = tableView.cellForRowAtIndexPath(indexPath) else { break }
             sourceIndexPath = indexPath
 
             // Add the snapshot as subview, aligned with the cell
@@ -204,7 +204,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
             center.y = location.y
             snapshot.center = center
 
-            guard let indexPath = indexPath, sourceIndexPath = sourceIndexPath
+            guard let sourceIndexPath = sourceIndexPath
                 where indexPath != sourceIndexPath else { break }
 
             // update data source & move rows
@@ -215,7 +215,9 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
             self.sourceIndexPath = indexPath
             break
         case .Ended, .Cancelled, .Failed:
-            guard let indexPath = indexPath, cell = tableView.cellForRowAtIndexPath(indexPath) else { break }
+            guard let cell = tableView.cellForRowAtIndexPath(indexPath) else {
+                break
+            }
             UIView.animateWithDuration(0.3, animations: { [unowned self] in
                 self.snapshot.center = cell.center
                 self.snapshot.transform = CGAffineTransformIdentity


### PR DESCRIPTION
If cell  exceeds the bottom row, `indexPathForRowAtPoint()` returns `nil`. To fix this, when `indexPathForRowAtPoint()` returns `nil`, it is treated as the end of the row.

CC @TimOliver @jpsim 

![screen shot 2016-06-23 at 11 58 28](https://cloud.githubusercontent.com/assets/40610/16316134/d174f410-3939-11e6-93c4-08ea21c250b5.png)
