### PR TITLE
Fix animation was jumped when adding row by dragging

### DIFF
--- a/RealmClear/ViewController.swift
+++ b/RealmClear/ViewController.swift
@@ -340,8 +340,6 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
 
         if scrollView.dragging {
             placeHolderCell.alpha = min(1, distancePulledDown / tableView.rowHeight)
-        } else {
-            placeHolderCell.alpha = 0.0
         }
     }
 
@@ -413,13 +411,19 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
         currentlyEditing = true
         let editingOffset = editingCell.convertRect(editingCell.bounds, toView: tableView).origin.y
         topConstraint?.constant = -editingOffset
-        UIView.animateWithDuration(0.3) { [unowned self] in
+
+        tableView.bounces = false
+
+        UIView.animateWithDuration(0.3, animations: { [unowned self] in
             self.view.layoutSubviews()
             self.textEditingCell.frame.origin.y = 45
             for cell in self.visibleTableViewCells where cell !== editingCell {
                 cell.alpha = 0.3
             }
-        }
+        }, completion: { [unowned self] finished in
+            self.placeHolderCell.alpha = 0.0
+            self.tableView.bounces = true
+        })
     }
 
     func cellDidEndEditing(editingCell: TableViewCell) {


### PR DESCRIPTION
Because scroll view bounce animation are finished before layout change animation block.

CC @TimOliver  @jpsim 
### BEFORE

![2016-06-24 14_07_30](https://cloud.githubusercontent.com/assets/40610/16350734/6ffd54b6-3a15-11e6-8671-e608630523bb.gif)
### AFTER

![2016-06-24 14_15_35](https://cloud.githubusercontent.com/assets/40610/16350845/2ef67c62-3a16-11e6-8a01-befba4a8ab66.gif)
