### PR TITLE
Fix editing an item animates it to the wrong offset

### DIFF
--- a/RealmClear/ViewController.swift
+++ b/RealmClear/ViewController.swift
@@ -408,7 +408,9 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
 
     func cellDidBeginEditing(editingCell: TableViewCell) {
         currentlyEditing = true
-        topConstraint?.constant = tableView.rowHeight
+
+        let editingOffset = editingCell.convertRect(editingCell.bounds, toView: tableView).origin.y
+        topConstraint?.constant = -editingOffset
 
         placeHolderCell.alpha = 0.0
         tableView.bounces = false


### PR DESCRIPTION
Fix https://github.com/realm/RealmClear/issues/26

This bug was introduced by https://github.com/realm/RealmClear/commit/a047050703b88ba5004de481d4de791526412e3e. It replaces some magic numbers...😰

CC @jpsim @TimOliver 
