### PR TITLE
Added Realm Confidential license to all source files

### DIFF
--- a/RealmTasks/AppDelegate.swift
+++ b/RealmTasks/AppDelegate.swift
@@ -1,10 +1,22 @@
-//
-//  AppDelegate.swift
-//  RealmTasks
-//
-//  Created by JP Simard on 4/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
+/*************************************************************************
+ *
+ * REALM CONFIDENTIAL
+ * __________________
+ *
+ *  [2016] Realm Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Realm Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Realm Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Realm Incorporated.
+ *
+ **************************************************************************/
 
 import RealmSwift
 import UIKit

--- a/RealmTasks/OnboardView.swift
+++ b/RealmTasks/OnboardView.swift
@@ -1,10 +1,22 @@
-//
-//  OnboardView.swift
-//  RealmClear
-//
-//  Created by Tim Oliver on 15/07/2016.
-//  Copyright © 2016 Realm. All rights reserved.
-//
+/*************************************************************************
+ *
+ * REALM CONFIDENTIAL
+ * __________________
+ *
+ *  [2016] Realm Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Realm Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Realm Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Realm Incorporated.
+ *
+ **************************************************************************/
 
 import Foundation
 import Cartography

--- a/RealmTasks/RealmColor.swift
+++ b/RealmTasks/RealmColor.swift
@@ -1,10 +1,22 @@
-//
-//  RealmColor.swift
-//  RealmTasks
-//
-//  Created by Tim Oliver on 1/07/2016.
-//  Copyright © 2016 Realm. All rights reserved.
-//
+/*************************************************************************
+ *
+ * REALM CONFIDENTIAL
+ * __________________
+ *
+ *  [2016] Realm Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Realm Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Realm Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Realm Incorporated.
+ *
+ **************************************************************************/
 
 import Foundation
 import UIKit

--- a/RealmTasks/TableViewCell.swift
+++ b/RealmTasks/TableViewCell.swift
@@ -1,10 +1,22 @@
-//
-//  TableViewCell.swift
-//  RealmTasks
-//
-//  Created by JP Simard on 4/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
+/*************************************************************************
+ *
+ * REALM CONFIDENTIAL
+ * __________________
+ *
+ *  [2016] Realm Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Realm Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Realm Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Realm Incorporated.
+ *
+ **************************************************************************/
 
 import AudioToolbox
 import Cartography

--- a/RealmTasks/ToDoItem.swift
+++ b/RealmTasks/ToDoItem.swift
@@ -1,10 +1,22 @@
-//
-//  ToDoItem.swift
-//  RealmTasks
-//
-//  Created by JP Simard on 4/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
+/*************************************************************************
+ *
+ * REALM CONFIDENTIAL
+ * __________________
+ *
+ *  [2016] Realm Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Realm Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Realm Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Realm Incorporated.
+ *
+ **************************************************************************/
 
 import Foundation
 import RealmSwift

--- a/RealmTasks/ToDoTextView.swift
+++ b/RealmTasks/ToDoTextView.swift
@@ -1,10 +1,22 @@
-//
-//  ToDoTextView.swift
-//  RealmTasks
-//
-//  Created by JP Simard on 4/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
+/*************************************************************************
+ *
+ * REALM CONFIDENTIAL
+ * __________________
+ *
+ *  [2016] Realm Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Realm Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Realm Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Realm Incorporated.
+ *
+ **************************************************************************/
 
 import UIKit
 

--- a/RealmTasks/ViewController.swift
+++ b/RealmTasks/ViewController.swift
@@ -1,10 +1,22 @@
-//
-//  ViewController.swift
-//  RealmTasks
-//
-//  Created by JP Simard on 4/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
+/*************************************************************************
+ *
+ * REALM CONFIDENTIAL
+ * __________________
+ *
+ *  [2016] Realm Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Realm Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Realm Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Realm Incorporated.
+ *
+ **************************************************************************/
 
 import Cartography
 import RealmSwift

--- a/RealmTasksTests/RealmTasksTests.swift
+++ b/RealmTasksTests/RealmTasksTests.swift
@@ -1,10 +1,22 @@
-//
-//  RealmTasksTests.swift
-//  RealmTasksTests
-//
-//  Created by JP Simard on 4/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
+/*************************************************************************
+ *
+ * REALM CONFIDENTIAL
+ * __________________
+ *
+ *  [2016] Realm Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Realm Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Realm Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Realm Incorporated.
+ *
+ **************************************************************************/
 
 import XCTest
 


### PR DESCRIPTION
As we're going to start sharing this codebase with external companies before Realm Sync is officially announced, I feel we should do our due diligence in making each source file with the appropriate license highlighting its confidential nature.

In this case, the same confidential license agreement as used by Realm Core would be appropriate. It can be modified down the line once we go live.
