### PR TITLE
Fix table view cell editing animation

### DIFF
--- a/RealmTasks/ViewController.swift
+++ b/RealmTasks/ViewController.swift
@@ -89,6 +89,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
     }
     private var currentlyEditingIndexPath: NSIndexPath? = nil
     private var topConstraint: NSLayoutConstraint?
+    private var previousContentOffset = CGPoint.zero
 
     // Placeholder cell to use before being adding to the table view
     private let placeHolderCell = TableViewCell(style: .Default, reuseIdentifier: "cell")
@@ -543,7 +544,12 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
         currentlyEditingIndexPath = tableView.indexPathForCell(editingCell)
 
         let editingOffset = editingCell.convertRect(editingCell.bounds, toView: tableView).origin.y
-        topConstraint?.constant = -editingOffset
+        if editingOffset >= tableView.contentSize.height / 2 {
+            topConstraint?.constant = -editingOffset
+        } else {
+            topConstraint?.constant = -(editingOffset + distancePulledDown)
+        }
+        previousContentOffset = tableView.contentOffset
 
         placeHolderCell.alpha = 0.0
         tableView.bounces = false
@@ -564,9 +570,9 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
         currentlyEditingIndexPath = nil
 
         topConstraint?.constant = 0
-        UIView.animateWithDuration(0.3) { [weak self] in
-            guard let strongSelf = self else { return }
-            for cell in strongSelf.visibleTableViewCells where cell !== editingCell {
+        UIView.animateWithDuration(0.3) { [unowned self] in
+            self.tableView.contentOffset = self.previousContentOffset
+            for cell in self.visibleTableViewCells where cell !== editingCell {
                 cell.alpha = 1
             }
         }


### PR DESCRIPTION
Fix table view cell editing animation
- If table view was scrolled down before editing, the editing cell goes out of the screen

![2016-07-26 00_12_57](https://cloud.githubusercontent.com/assets/40610/17106297/c6039c3a-52c5-11e6-8f84-92a4556a6727.gif)
- Even if editing a lower cell, back to the top of the table view when finished

![2016-07-26 00_15_31](https://cloud.githubusercontent.com/assets/40610/17106435/42f4631e-52c6-11e6-8bd4-709cb30fa532.gif)
### After

![2016-07-26 00_19_47](https://cloud.githubusercontent.com/assets/40610/17106552/bb2102de-52c6-11e6-8191-10c7afcfe8ee.gif)

CC @TimOliver @jpsim 
