### PR TITLE
Fix an issue that data being edited is modified by sync, then UI will be inoperable

### DIFF
--- a/RealmTasks/TableViewCell.swift
+++ b/RealmTasks/TableViewCell.swift
@@ -73,6 +73,8 @@ final class TableViewCell: UITableViewCell, UITextViewDelegate {
     var delegate: TableViewCellDelegate?
     let textView = ToDoItemTextView()
 
+    var temporarilyIgnoreSaveChanges = false
+
     // Private Properties
 
     private var originalDoneIconCenter = CGPoint()
@@ -294,6 +296,7 @@ final class TableViewCell: UITableViewCell, UITextViewDelegate {
         super.prepareForReuse()
         alpha = 1.0
         contentView.alpha = 1.0
+        temporarilyIgnoreSaveChanges = false
     }
 
     // MARK: Actions
@@ -339,8 +342,10 @@ final class TableViewCell: UITableViewCell, UITextViewDelegate {
 
     func textViewDidEndEditing(textView: UITextView) {
         if let realm = item.realm {
-            try! realm.write {
-                item.text = textView.text
+            if !temporarilyIgnoreSaveChanges {
+                try! realm.write {
+                    item.text = textView.text
+                }
             }
         } else {
             item.text = textView.text

--- a/RealmTasks/ViewController.swift
+++ b/RealmTasks/ViewController.swift
@@ -222,8 +222,12 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
 
                 if let currentlyEditingIndexPath = self.currentlyEditingIndexPath {
                     UIView.performWithoutAnimation {
+                        // FIXME: Updating table view forces resigning first responder
+                        // If editing, unintended input state is committed and sync.
+                        self.currentlyEditingCell?.temporarilyIgnoreSaveChanges = true
                         updateTableView()
                         let currentlyEditingCell = self.tableView.cellForRowAtIndexPath(currentlyEditingIndexPath) as! TableViewCell
+                        currentlyEditingCell.temporarilyIgnoreSaveChanges = false
                         currentlyEditingCell.textView.becomeFirstResponder()
                     }
                 } else {


### PR DESCRIPTION
Fix https://github.com/realm/RealmTasks/issues/59
1. Updating table view forces resigning a first responder. Then `currentlyEditingCell` will be reused.  So re-fetch editing cell after updating table view. 3f72a26
2. Dirty workaround for avoiding unintended write due to force resigning a first responder by sync. 4d91d7d

CC @jpsim @TimOliver 
