### PR TITLE
apply consistent code style

### DIFF
--- a/RealmTasks Shared/RealmColor.swift
+++ b/RealmTasks Shared/RealmColor.swift
@@ -33,50 +33,50 @@ import Foundation
 extension Color {
 
     var realmColors: [Color] {
-        return [Color(red: 231.0/255.0, green: 167.0/255.0, blue: 118.0/255.0, alpha: 1.0),
-                Color(red: 228.0/255.0, green: 125.0/255.0, blue: 114.0/255.0, alpha: 1.0),
-                Color(red: 233.0/255.0, green: 99.0/255.0, blue: 111.0/255.0, alpha: 1.0),
-                Color(red: 242.0/255.0, green: 81.0/255.0, blue: 145.0/255.0, alpha: 1.0),
-                Color(red: 154.0/255.0, green: 80.0/255.0, blue: 164.0/255.0, alpha: 1.0),
-                Color(red: 88.0/255.0, green: 86.0/255.0, blue: 157.0/255.0, alpha: 1.0),
-                Color(red: 56.0/255.0, green: 71.0/255.0, blue: 126.0/255.0, alpha: 1.0)]
+        return [Color(red: 231/255, green: 167/255, blue: 118/255, alpha: 1),
+                Color(red: 228/255, green: 125/255, blue: 114/255, alpha: 1),
+                Color(red: 233/255, green: 99/255, blue: 111/255, alpha: 1),
+                Color(red: 242/255, green: 81/255, blue: 145/255, alpha: 1),
+                Color(red: 154/255, green: 80/255, blue: 164/255, alpha: 1),
+                Color(red: 88/255, green: 86/255, blue: 157/255, alpha: 1),
+                Color(red: 56/255, green: 71/255, blue: 126/255, alpha: 1)]
     }
 
     class func colorForRealmLogoGradient(offset: Double) -> Color {
         var newOffset = offset
 
-        // Ensure offset is normalized to 1.0
-        newOffset = min(newOffset, 1.0)
-        newOffset = max(newOffset, 0.0)
+        // Ensure offset is normalized to 1
+        newOffset = min(newOffset, 1)
+        newOffset = max(newOffset, 0)
 
         let realmLogoColors = Color().realmColors
 
         // Work out the 'size' that each color stop spans
-        let colorStopRange = 1.0 / Double(realmLogoColors.count-1)
+        let colorStopRange = 1 / Double(realmLogoColors.count-1)
 
         // Determine the base stop our offset is within
         let colorRangeIndex = Int(floor(newOffset / colorStopRange))
 
         // Get the initial color which will serve as the origin
         let topColor = realmLogoColors[colorRangeIndex]
-        var fromColors: [CGFloat] = [0.0, 0.0, 0.0]
+        var fromColors: [CGFloat] = [0, 0, 0]
         topColor.getRed(&fromColors[0], green: &fromColors[1], blue: &fromColors[2], alpha: nil)
 
         // Get the destination color we will lerp to
         let bottomColor = realmLogoColors[colorRangeIndex + 1]
-        var toColors: [CGFloat] = [0.0, 0.0, 0.0]
+        var toColors: [CGFloat] = [0, 0, 0]
         bottomColor.getRed(&toColors[0], green: &toColors[1], blue: &toColors[2], alpha: nil)
 
         // Work out the actual percentage we need to lerp, inside just that stop range
         let stopOffset = (newOffset - (Double(colorRangeIndex) * colorStopRange)) / colorStopRange
 
         // Perform the interpolation
-        var finalColors: [CGFloat] = [0.0, 0.0, 0.0]
+        var finalColors: [CGFloat] = [0, 0, 0]
         finalColors[0] = fromColors[0] + CGFloat(stopOffset) * (toColors[0] - fromColors[0])
         finalColors[1] = fromColors[1] + CGFloat(stopOffset) * (toColors[1] - fromColors[1])
         finalColors[2] = fromColors[2] + CGFloat(stopOffset) * (toColors[2] - fromColors[2])
 
-        return Color(red: finalColors[0], green: finalColors[1], blue: finalColors[2], alpha: 1.0)
+        return Color(red: finalColors[0], green: finalColors[1], blue: finalColors[2], alpha: 1)
     }
 
 }

--- a/RealmTasks iOS/OnboardView.swift
+++ b/RealmTasks iOS/OnboardView.swift
@@ -22,33 +22,32 @@ import Foundation
 import Cartography
 import UIKit
 
-class OnboardView: UIView
-{
-    let contentColor = UIColor(white: 0.13, alpha: 1.0)
-    let contentPadding = 15.0
+class OnboardView: UIView {
+    let contentColor = UIColor(white: 0.13, alpha: 1)
+    let contentPadding: CGFloat = 15
 
     let imageView = UIImageView(image: UIImage(named: "PullToRefresh")?.imageWithRenderingMode(.AlwaysTemplate))
     let labelView = UILabel()
 
     init() {
         labelView.text = "Pull Down to Start"
-        labelView.font = UIFont.systemFontOfSize(20, weight: UIFontWeightMedium)
+        labelView.font = .systemFontOfSize(20, weight: UIFontWeightMedium)
         labelView.textColor = contentColor
         labelView.textAlignment = .Center
         labelView.sizeToFit()
 
         imageView.tintColor = contentColor
 
-        var frame = CGRectZero
+        var frame = CGRect.zero
         frame.size.width = labelView.frame.size.width
-        frame.size.height = CGRectGetHeight(imageView.frame) + CGFloat(contentPadding) + CGRectGetHeight(labelView.frame)
+        frame.size.height = CGRectGetHeight(imageView.frame) + contentPadding + CGRectGetHeight(labelView.frame)
 
         super.init(frame: frame)
 
-        self.addSubview(imageView)
-        self.addSubview(labelView)
+        addSubview(imageView)
+        addSubview(labelView)
 
-        self.autoresizingMask = [.FlexibleBottomMargin, .FlexibleTopMargin, .FlexibleLeftMargin, .FlexibleRightMargin]
+        autoresizingMask = [.FlexibleBottomMargin, .FlexibleTopMargin, .FlexibleLeftMargin, .FlexibleRightMargin]
 
         setupConstraints()
     }

--- a/RealmTasks iOS/TableViewCell.swift
+++ b/RealmTasks iOS/TableViewCell.swift
@@ -114,13 +114,13 @@ final class TableViewCell: UITableViewCell, UITextViewDelegate {
     private func setupIconViews() {
         doneIconView.center = center
         doneIconView.frame.origin.x = 20
-        doneIconView.alpha = 0.0
+        doneIconView.alpha = 0
         doneIconView.autoresizingMask = [.FlexibleRightMargin, .FlexibleTopMargin, .FlexibleBottomMargin]
         insertSubview(doneIconView, belowSubview: contentView)
 
         deleteIconView.center = center
         deleteIconView.frame.origin.x = bounds.width - deleteIconView.bounds.width - 20
-        deleteIconView.alpha = 0.0
+        deleteIconView.alpha = 0
         deleteIconView.autoresizingMask = [.FlexibleLeftMargin, .FlexibleTopMargin, .FlexibleBottomMargin]
         insertSubview(deleteIconView, belowSubview: contentView)
     }
@@ -199,7 +199,7 @@ final class TableViewCell: UITableViewCell, UITextViewDelegate {
                 deleteIconView.center = CGPoint(x: originalDeleteIconCenter.x - x, y: originalDeleteIconCenter.y)
             }
 
-            if translation.x > 0.0 {
+            if translation.x > 0 {
                 doneIconView.alpha = CGFloat(fractionOfThreshold)
             } else {
                 deleteIconView.alpha = CGFloat(fractionOfThreshold)
@@ -233,15 +233,15 @@ final class TableViewCell: UITableViewCell, UITextViewDelegate {
             switch releaseAction {
             case .Complete?:
                 animationBlock = {
-                    self.contentView.frame.origin.x = 0.0
+                    self.contentView.frame.origin.x = 0
                 }
                 completionBlock = {
                     self.setCompleted(!self.item.completed, animated: true)
                 }
             case .Delete?:
                 animationBlock = {
-                    self.alpha = 0.0
-                    self.contentView.alpha = 0.0
+                    self.alpha = 0
+                    self.contentView.alpha = 0
 
                     self.contentView.frame.origin.x = -self.contentView.bounds.width - (self.bounds.size.width / 4)
                     self.deleteIconView.frame.origin.x = -(self.bounds.size.width / 4) + self.deleteIconView.bounds.width + 20
@@ -252,7 +252,7 @@ final class TableViewCell: UITableViewCell, UITextViewDelegate {
             case nil:
                 item.completed ? textView.strike() : textView.unstrike()
                 animationBlock = {
-                    self.contentView.frame.origin.x = 0.0
+                    self.contentView.frame.origin.x = 0
                 }
                 completionBlock = {}
             }
@@ -264,10 +264,10 @@ final class TableViewCell: UITableViewCell, UITextViewDelegate {
                 completionBlock()
 
                 self.doneIconView.frame.origin.x = 20
-                self.doneIconView.alpha = 0.0
+                self.doneIconView.alpha = 0
 
                 self.deleteIconView.frame.origin.x = self.bounds.width - self.deleteIconView.bounds.width - 20
-                self.deleteIconView.alpha = 0.0
+                self.deleteIconView.alpha = 0
             })
         default:
             break
@@ -284,8 +284,8 @@ final class TableViewCell: UITableViewCell, UITextViewDelegate {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        alpha = 1.0
-        contentView.alpha = 1.0
+        alpha = 1
+        contentView.alpha = 1
         temporarilyIgnoreSaveChanges = false
     }
 

--- a/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks iOS/ViewController.swift
@@ -50,7 +50,7 @@ private func delay(time: Double, block: () -> ()) {
 }
 
 private func degreesToRadians(value: Double) -> Double {
-    return value * M_PI / 180.0
+    return value * M_PI / 180
 }
 
 // MARK: View Controller
@@ -145,7 +145,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
     private func setupPlaceholderCell() {
         placeHolderCell.alpha = 0
         placeHolderCell.backgroundView!.backgroundColor = UIColor().realmColors[0]
-        placeHolderCell.layer.anchorPoint = CGPoint(x: 0.5, y: 1.0)
+        placeHolderCell.layer.anchorPoint = CGPoint(x: 0.5, y: 1)
         tableView.addSubview(placeHolderCell)
         constrain(placeHolderCell) { placeHolderCell in
             placeHolderCell.bottom == placeHolderCell.superview!.topMargin - 7 + 26
@@ -184,7 +184,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
             return
         }
 
-        notificationToken = items.addNotificationBlock({ (changes: RealmCollectionChange) in
+        notificationToken = items.addNotificationBlock { changes in
             if self.disableNotificationsState {
                 return
             }
@@ -241,7 +241,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
                 // An error occurred while opening the Realm file on the background worker thread
                 fatalError("\(error)")
             }
-        })
+        }
     }
 
     func cellHeightForText(text: NSString) -> CGFloat {
@@ -265,14 +265,14 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
         let hidden = (numberOfRows > 0 || textEditingCell.superview != nil)
 
         if animated == false {
-            onboardView.alpha = hidden ? 0.0 : 1.0
+            onboardView.alpha = hidden ? 0 : 1
             return
         }
 
-        onboardView.alpha = hidden ? 1.0 : 0.0
-        UIView.animateWithDuration(0.3, animations: {
-            self.onboardView.alpha = hidden ? 0.0 : 1.0
-        })
+        onboardView.alpha = hidden ? 1 : 0
+        UIView.animateWithDuration(0.3) {
+            self.onboardView.alpha = hidden ? 0 : 1
+        }
     }
 
     // MARK: Gesture Recognizers
@@ -425,8 +425,8 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
     }
 
     func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
-        cell.contentView.backgroundColor = self.realmColor(forIndexPath: indexPath)
-        cell.alpha = currentlyEditing ? editingCellAlpha : 1.0
+        cell.contentView.backgroundColor = realmColor(forIndexPath: indexPath)
+        cell.alpha = currentlyEditing ? editingCellAlpha : 1
     }
 
     // MARK: UIScrollViewDelegate methods
@@ -441,16 +441,15 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
             let angle = CGFloat(degreesToRadians(90)) - tan(distancePulledDown / cellHeight)
 
             var transform = CATransform3DIdentity
-            transform.m34 = 1.0 / -(1000 * 0.2)
-            transform = CATransform3DRotate(transform, angle, 1.0, 0.0, 0.0)
+            transform.m34 = 1 / -(1000 * 0.2)
+            transform = CATransform3DRotate(transform, angle, 1, 0, 0)
 
             placeHolderCell.layer.transform = transform
 
             if tableView.numberOfRowsInSection(0) == 0 {
-                onboardView.alpha = max(0.0, 1.0 - (distancePulledDown / cellHeight))
-            }
-            else {
-                onboardView.alpha = 0.0
+                onboardView.alpha = max(0, 1 - (distancePulledDown / cellHeight))
+            } else {
+                onboardView.alpha = 0
             }
         } else {
             placeHolderCell.layer.transform = CATransform3DIdentity
@@ -556,7 +555,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
         }
         previousContentOffset = tableView.contentOffset
 
-        placeHolderCell.alpha = 0.0
+        placeHolderCell.alpha = 0
         tableView.bounces = false
 
         UIView.animateWithDuration(0.3, animations: { [unowned self] in
@@ -587,9 +586,9 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
                 items.insert(item, atIndex: 0)
             }
 
-            UIView.performWithoutAnimation({
+            UIView.performWithoutAnimation {
                 self.tableView.insertRowsAtIndexPaths([NSIndexPath(forRow: 0, inSection: 0)], withRowAnimation: .None)
-            })
+            }
             temporarilyDisableNotifications()
 
             updateColors()
@@ -600,7 +599,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
             }
         }
 
-        if let _ = textEditingCell.superview {
+        if textEditingCell.superview != nil {
             textEditingCell.removeFromSuperview()
         }
 
@@ -610,20 +609,20 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
     func cellDidChangeText(editingCell: TableViewCell) {
         // If the height of the text view has extended to the next line,
         // reload the height of the cell
-        let height = self.cellHeightForText(editingCell.textView.text)
+        let height = cellHeightForText(editingCell.textView.text)
         if Int(height) != Int(editingCell.frame.size.height) {
             UIView.performWithoutAnimation {
                 self.tableView.beginUpdates()
                 self.tableView.endUpdates()
             }
 
-            for cell in self.visibleTableViewCells where cell !== editingCell {
+            for cell in visibleTableViewCells where cell !== editingCell {
                 cell.alpha = editingCellAlpha
             }
 
             if editingCell == textEditingCell {
                 var frame = textEditingCell.frame
-                frame.size.height = self.cellHeightForText(textEditingCell.textView.text)
+                frame.size.height = cellHeightForText(textEditingCell.textView.text)
                 textEditingCell.frame = frame
                 textEditingCell.textView.sizeToFit()
                 textEditingCell.layoutSubviews()
@@ -631,7 +630,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
 
                 let editingOffset = editingCell.convertRect(textEditingCell.bounds, toView: tableView).origin.y
                 topConstraint?.constant = -editingOffset
-                self.view.layoutSubviews()
+                view.layoutSubviews()
             }
         }
     }
@@ -639,7 +638,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
     // MARK: Actions
 
     private func realmColor(forIndexPath indexPath: NSIndexPath) -> UIColor {
-        return UIColor.colorForRealmLogoGradient(Double(indexPath.row) / Double(max(13, tableView.numberOfRowsInSection(0))))
+        return .colorForRealmLogoGradient(Double(indexPath.row) / Double(max(13, tableView.numberOfRowsInSection(0))))
     }
 
     private func updateColors(completion completion: (() -> Void)? = nil) {
@@ -656,6 +655,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
     }
 
     // MARK: Sync
+
     private func temporarilyDisableNotifications(reloadTable reloadTable: Bool = true) {
         disableNotificationsState = true
         delay(0.3) {

--- a/RealmTasks macOS/ToDoItemCellView.swift
+++ b/RealmTasks macOS/ToDoItemCellView.swift
@@ -31,7 +31,7 @@ class ToDoItemCellView: NSTableCellView {
     func configureWithToDoItem(item: ToDoItem, color: NSColor) {
         textField?.stringValue = item.text
         
-        backgroundColor = item.completed ? NSColor.completeDimBackgroundColor() : color
+        backgroundColor = item.completed ? .completeDimBackgroundColor() : color
     }
     
     override func drawRect(dirtyRect: NSRect) {

--- a/RealmTasks macOS/ToDoListViewController.swift
+++ b/RealmTasks macOS/ToDoListViewController.swift
@@ -89,7 +89,7 @@ extension ToDoListViewController: NSTableViewDelegate {
     }
     
     private func realmColor(forRow row: Int) -> NSColor {
-        return NSColor.colorForRealmLogoGradient(Double(row) / Double(max(13, tableView.numberOfRows)))
+        return .colorForRealmLogoGradient(Double(row) / Double(max(13, tableView.numberOfRows)))
     }
     
 }


### PR DESCRIPTION
- avoid unnecessary type casts
- only explicitly refer to `self` when required
- prefer trailing closures
- omit `.0` on floating point numbers when the inferred type is correct
- omit the type when invoking class methods when it can be inferred
