### PR TITLE
fix onboard view flash on toggle

### DIFF
--- a/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks iOS/ViewController.swift
@@ -270,7 +270,6 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
             return
         }
 
-        onboardView.alpha = hidden ? 1 : 0
         UIView.animateWithDuration(0.3) {
             self.onboardView.alpha = hidden ? 0 : 1
         }


### PR DESCRIPTION
by animating from its current alpha rather than setting to 1 before animating. Fixes #66.
