### PR TITLE
append new items when tapping empty area under existing tasks

### DIFF
--- a/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks iOS/ViewController.swift
@@ -297,6 +297,17 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
             cell = tableView.cellForRowAtIndexPath(indexPath) as? TableViewCell {
             cell.textView.userInteractionEnabled = !cell.textView.userInteractionEnabled
             cell.textView.becomeFirstResponder()
+        } else {
+            try! items.realm?.write {
+                items.append(ToDoItem())
+            }
+            let indexPath = NSIndexPath(forRow: items.count - 1, inSection: 0)
+            tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .None)
+            toggleOnboardView(animated: true)
+            skipNextNotification()
+            let cell = tableView.cellForRowAtIndexPath(indexPath) as! TableViewCell
+            cell.textView.userInteractionEnabled = !cell.textView.userInteractionEnabled
+            cell.textView.becomeFirstResponder()
         }
     }
 


### PR DESCRIPTION
This could be improved by an animation like Clear does, but at least this exposes the functionality for now.

![append](https://cloud.githubusercontent.com/assets/474794/17265410/9569ea8a-55a3-11e6-9328-9422ba933708.gif)
