### PR TITLE
improvements to how row colors are obtained

### DIFF
--- a/RealmTasks Shared/RealmColor.swift
+++ b/RealmTasks Shared/RealmColor.swift
@@ -31,8 +31,7 @@ import Foundation
 #endif
 
 extension Color {
-
-    private static func realmColors() -> [Color] {
+    static func taskColors() -> [Color] {
         return [
             Color(red: 231/255, green: 167/255, blue: 118/255, alpha: 1),
             Color(red: 228/255, green: 125/255, blue: 114/255, alpha: 1),
@@ -43,26 +42,26 @@ extension Color {
             Color(red: 56/255, green: 71/255, blue: 126/255, alpha: 1)
         ]
     }
+}
 
-    class func colorForRealmLogoGradient(offset: Double) -> Color {
+extension CollectionType where Generator.Element == Color, Index == Int {
+    func gradientColorAtFraction(fraction: Double) -> Color {
         // Ensure offset is normalized to 1
-        let normalizedOffset = max(min(offset, 1), 0)
-
-        let realmLogoColors = realmColors()
+        let normalizedOffset = max(min(fraction, 1), 0)
 
         // Work out the 'size' that each color stop spans
-        let colorStopRange = 1 / Double(realmLogoColors.count - 1)
+        let colorStopRange = 1 / Double(count - 1)
 
         // Determine the base stop our offset is within
         let colorRangeIndex = Int(floor(normalizedOffset / colorStopRange))
 
         // Get the initial color which will serve as the origin
-        let topColor = realmLogoColors[colorRangeIndex]
+        let topColor = self[colorRangeIndex]
         var fromColors: [CGFloat] = [0, 0, 0]
         topColor.getRed(&fromColors[0], green: &fromColors[1], blue: &fromColors[2], alpha: nil)
 
         // Get the destination color we will lerp to
-        let bottomColor = realmLogoColors[colorRangeIndex + 1]
+        let bottomColor = self[colorRangeIndex + 1]
         var toColors: [CGFloat] = [0, 0, 0]
         bottomColor.getRed(&toColors[0], green: &toColors[1], blue: &toColors[2], alpha: nil)
 
@@ -75,7 +74,6 @@ extension Color {
         }
         return Color(red: finalColors[0], green: finalColors[1], blue: finalColors[2], alpha: 1)
     }
-
 }
 
 extension Color {

--- a/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks iOS/ViewController.swift
@@ -142,7 +142,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
 
     private func setupPlaceholderCell() {
         placeHolderCell.alpha = 0
-        placeHolderCell.backgroundView!.backgroundColor = .colorForRealmLogoGradient(0)
+        placeHolderCell.backgroundView!.backgroundColor = rowColor(atIndex: 0)
         placeHolderCell.layer.anchorPoint = CGPoint(x: 0.5, y: 1)
         tableView.addSubview(placeHolderCell)
         constrain(placeHolderCell) { placeHolderCell in
@@ -445,7 +445,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
     }
 
     func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
-        cell.contentView.backgroundColor = realmColor(forIndexPath: indexPath)
+        cell.contentView.backgroundColor = rowColor(atIndex: indexPath.row)
         cell.alpha = currentlyEditing ? editingCellAlpha : 1
     }
 
@@ -627,13 +627,14 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
 
     // MARK: Actions
 
-    private func realmColor(forIndexPath indexPath: NSIndexPath) -> UIColor {
-        return .colorForRealmLogoGradient(Double(indexPath.row) / Double(max(13, tableView.numberOfRowsInSection(0))))
+    private func rowColor(atIndex index: Int) -> UIColor {
+        let fraction = Double(index) / Double(max(13, tableView.numberOfRowsInSection(0)))
+        return UIColor.taskColors().gradientColorAtFraction(fraction)
     }
 
     private func updateColors(completion completion: (() -> Void)? = nil) {
         let visibleCellsAndColors = visibleTableViewCells.map { cell in
-            return (cell, realmColor(forIndexPath: tableView.indexPathForCell(cell)!))
+            return (cell, rowColor(atIndex: tableView.indexPathForCell(cell)!.row))
         }
 
         UIView.animateWithDuration(0.5, animations: {

--- a/RealmTasks macOS/ToDoListViewController.swift
+++ b/RealmTasks macOS/ToDoListViewController.swift
@@ -174,7 +174,7 @@ extension ToDoListViewController: NSTableViewDelegate {
         }
 
         cellView.configureWithToDoItem(items[row])
-        cellView.backgroundColor = self.realmColor(forRow: row)
+        cellView.backgroundColor = rowColor(atIndex: row)
         cellView.delegate = self
 
         return cellView
@@ -203,14 +203,15 @@ extension ToDoListViewController: NSTableViewDelegate {
             // For some reason tableView.viewAtColumn:row: returns nil while animating, will use view hierarchy instead
             if let cellView = rowView.subviews.first as? ToDoItemCellView {
                 NSView.animateWithDuration(5, animations: {
-                    cellView.backgroundColor = self.realmColor(forRow: row)
+                    cellView.backgroundColor = self.rowColor(atIndex: row)
                 })
             }
         }
     }
     
-    private func realmColor(forRow row: Int) -> NSColor {
-        return .colorForRealmLogoGradient(Double(row) / Double(max(13, tableView.numberOfRows)))
+    private func rowColor(atIndex index: Int) -> NSColor {
+        let fraction = Double(index) / Double(max(13, tableView.numberOfRows))
+        return NSColor.taskColors().gradientColorAtFraction(fraction)
     }
     
 }


### PR DESCRIPTION
- rename Color.realmColors() to taskColors()
- generalize Color.colorForRealmLogoGradient(...) into collection extension
- rename realmColor(forIndexPath:) to rowColor(atIndex:) and align iOS & macOS

in preparation for more color schemes (e.g. for lists)
