### PR TITLE
explicitly set the object types used in Realm configurations

### DIFF
--- a/RealmTasks Shared/RealmConfigurations.swift
+++ b/RealmTasks Shared/RealmConfigurations.swift
@@ -27,5 +27,6 @@ let userRealmConfiguration = Realm.Configuration(
 )
 
 let syncRealmConfiguration = Realm.Configuration(
-    syncServerURL: Constants.syncServerURL
+    syncServerURL: Constants.syncServerURL,
+    objectTypes: [ToDoList.self, ToDoItem.self]
 )

--- a/RealmTasks Shared/User.swift
+++ b/RealmTasks Shared/User.swift
@@ -23,8 +23,4 @@ import RealmSwift
 
 final class User: Object {
     dynamic var accessToken = ""
-
-    override class func shouldIncludeInDefaultSchema() -> Bool {
-        return false
-    }
 }


### PR DESCRIPTION
this will simplify things when we have more than just 2 configurations due to supporting multiple lists
