### PR TITLE
use row animation .None for reloadRowsAtIndexPaths

### DIFF
--- a/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks iOS/ViewController.swift
@@ -226,7 +226,7 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
                     self.tableView.beginUpdates()
                     self.tableView.insertRowsAtIndexPaths(insertions.map { NSIndexPath(forRow: $0, inSection: 0) }, withRowAnimation: .Automatic)
                     self.tableView.deleteRowsAtIndexPaths(deletions.map { NSIndexPath(forRow: $0, inSection: 0) }, withRowAnimation: .Automatic)
-                    self.tableView.reloadRowsAtIndexPaths(modifications.map { NSIndexPath(forRow: $0, inSection: 0) },withRowAnimation: .Automatic)
+                    self.tableView.reloadRowsAtIndexPaths(modifications.map { NSIndexPath(forRow: $0, inSection: 0) }, withRowAnimation: .None)
                     self.tableView.endUpdates()
                 }
 


### PR DESCRIPTION
What do you guys think of disabling this fade animation when rows are reloaded? /cc @TimOliver @kishikawakatsumi 

**Before**

![cell_update_before](https://cloud.githubusercontent.com/assets/474794/17395090/6d43f770-59e1-11e6-8d22-f0ce07622f26.gif)

**After**

![cell_update_after](https://cloud.githubusercontent.com/assets/474794/17395094/71d8e836-59e1-11e6-8b6d-9b5ecb6c344f.gif)
