### PR TITLE
set Constants.syncHost to 127.0.0.1 on OS X debug

### DIFF
--- a/RealmTasks Shared/Constants.swift
+++ b/RealmTasks Shared/Constants.swift
@@ -22,7 +22,11 @@ import Foundation
 
 struct Constants {
     #if DEBUG
+    #if os(OSX)
+    static let syncHost = "127.0.0.1"
+    #else
     static let syncHost = localIPAddress
+    #endif
     #else
     static let syncHost = "SPECIFY_PRODUCTION_HOST_HERE"
     #endif


### PR DESCRIPTION
so that we can package a prebuilt version of the Mac app in sync releases and still have it connect to the local sync services.

/cc @stel @radu-tutueanu 
