### PR TITLE
Use different bundle identifiers for different platforms

### DIFF
--- a/RealmTasks.xcodeproj/project.pbxproj
+++ b/RealmTasks.xcodeproj/project.pbxproj
@@ -536,7 +536,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/$(TARGET_NAME)/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				PRODUCT_BUNDLE_IDENTIFIER = io.realm.tasks.macos;
+				PRODUCT_BUNDLE_IDENTIFIER = io.realm.realmtasks.macos;
 				PRODUCT_NAME = "Realm Tasks";
 				SDKROOT = macosx;
 			};
@@ -553,7 +553,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/$(TARGET_NAME)/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				PRODUCT_BUNDLE_IDENTIFIER = io.realm.tasks.macos;
+				PRODUCT_BUNDLE_IDENTIFIER = io.realm.realmtasks.macos;
 				PRODUCT_NAME = "Realm Tasks";
 				SDKROOT = macosx;
 			};
@@ -651,7 +651,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = "$(SRCROOT)/$(TARGET_NAME)/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.realm.tasks.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = io.realm.realmtasks.ios;
 				PRODUCT_NAME = "Realm Tasks";
 			};
 			name = Debug;
@@ -664,7 +664,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = "$(SRCROOT)/$(TARGET_NAME)/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.realm.tasks.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = io.realm.realmtasks.ios;
 				PRODUCT_NAME = "Realm Tasks";
 			};
 			name = Release;


### PR DESCRIPTION
For distributing apps on the AppStore every app should have a unique identifier, I usually use platform name as a last component in bundle identifier. Even if we're not going to distribute this apps on the AppStore I would recommend to change identifiers.
