### PR TITLE
Fix test cases

### DIFF
--- a/RealmTasks iOS Tests/RealmTasksTests.swift
+++ b/RealmTasks iOS Tests/RealmTasksTests.swift
@@ -59,6 +59,15 @@ class RealmTasksTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
+        if realm.inWriteTransaction {
+            realm.cancelWrite()
+        }
+        
+        if let textView = vc.view.currentFirstResponder as? UITextView {
+            textView.delegate = nil
+            endEditing()
+        }
+
         let taskList = realm.objects(TaskList.self).first!
         try! realm.write {
             taskList.items.removeAll()
@@ -93,7 +102,7 @@ class RealmTasksTests: XCTestCase {
         insertItemFromSync()
         wait()
 
-        XCTAssertEqual(vc.tableView(vc.tableView, numberOfRowsInSection: 0), 1)
+        XCTAssertEqual(vc.tableView(vc.tableView, numberOfRowsInSection: 0), 3)
     }
 
     func testDeleteItem() {
@@ -195,7 +204,7 @@ class RealmTasksTests: XCTestCase {
 
     private func completeItemAt(indexPath: NSIndexPath) {
         let cell = vc.tableView.cellForRowAtIndexPath(indexPath) as! TableViewCell<Task>
-        cell.itemDeleted?(cell.item)
+        cell.itemCompleted?(cell.item)
     }
 
     private func setTextToEditingCell(text: String) {


### PR DESCRIPTION
- Fix crash on `tearDown()` after an exception was occurred in a test case
- Fix wrong assert https://github.com/realm/RealmTasks/compare/kk/fix-tests?expand=1#diff-a082f0a499dc7e8c045b26d20edc53c5R105
- Fix wrong method call (`itemDeleted()` in `completeItemAt()` https://github.com/realm/RealmTasks/compare/kk/fix-tests?expand=1#diff-a082f0a499dc7e8c045b26d20edc53c5R207
