### PR TITLE
Workaround for crash sync occurred while editing

### DIFF
--- a/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks iOS/ViewController.swift
@@ -762,18 +762,18 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
         }
 
         let item = editingCell.item
-        if !(item as Object).invalidated {
-            if item.text.isEmpty {
-                try! item.realm?.write {
-                    item.realm!.delete(item)
-                }
-                tableView.deleteRowsAtIndexPaths([tableView.indexPathForCell(editingCell)!], withRowAnimation: .None)
-            }
-            skipNextNotification()
-            toggleOnboardView()
-        } else {
+        guard !(item as Object).invalidated else {
             tableView.reloadData()
+            return
         }
+        if item.text.isEmpty {
+            try! item.realm?.write {
+                item.realm!.delete(item)
+            }
+            tableView.deleteRowsAtIndexPaths([tableView.indexPathForCell(editingCell)!], withRowAnimation: .None)
+        }
+        skipNextNotification()
+        toggleOnboardView()
     }
 
     private func cellDidChangeText(editingCell: TableViewCell<Item>) {


### PR DESCRIPTION
Workaround for https://github.com/realm/RealmTasks/issues/133 and https://github.com/realm/RealmTasks/issues/134
- Skip update table view while editing.
- Ignore saving changes if the item already deleted from another device.

@jpsim @TimOliver @stel 
