### PR TITLE
fix duplicate default list references

### DIFF
--- a/RealmTasks Shared/Constants.swift
+++ b/RealmTasks Shared/Constants.swift
@@ -33,6 +33,7 @@ struct Constants {
 
     static let syncRealmPath = "realmtasks"
     static let defaultListName = "My Tasks"
+    static let defaultListID = "80EB1620-165B-4600-A1B1-D97032FDD9A0"
 
     static let syncServerURL = NSURL(string: "realm://\(syncHost)/~/\(syncRealmPath)")
     static let syncAuthURL = NSURL(string: "http://\(syncHost):8080")!


### PR DESCRIPTION
Until core supports ordered sets: realm/realm-core#1206

Without this, if you log in from a new device after first having synced with a first device, you'll get duplicate references to the default list in the Lists screen.
