### PR TITLE
Fix for ViewController retain cycle

### DIFF
--- a/RealmTasks iOS/TableViewCell.swift
+++ b/RealmTasks iOS/TableViewCell.swift
@@ -127,7 +127,7 @@ final class TableViewCell<Item: Object where Item: CellPresentable>: UITableView
         cellDidEndEditing = nil
         cellDidChangeText = nil
     }
-    
+
     private func setupBackgroundView() {
         backgroundColor = .clearColor()
 

--- a/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks iOS/ViewController.swift
@@ -138,7 +138,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             title = parent.text
         }
     }
-    
+
     deinit {
         tableView.removeObserver(self, forKeyPath: "bounds")
         parent.removeObserver(self, forKeyPath: "text")
@@ -449,7 +449,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
 
         return cell
     }
-    
+
     private func cellHeightForText(text: String) -> CGFloat {
         return text.boundingRectWithSize(CGSize(width: view.bounds.size.width - 25, height: view.bounds.size.height),
                                          options: [.UsesLineFragmentOrigin],
@@ -487,7 +487,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
         let itemCell = cell as! TableViewCell<Item>
         itemCell.reset()
     }
-    
+
     private func navigateToBottomViewController(item: Item) {
         bottomViewController = ViewController<Task, TaskList>(
             parent: item as! TaskList,


### PR DESCRIPTION
Fixes #214.

It turns out that assigning callback functions/closures to each `TableViewCell<Item>` was creating a strong reference back to the parent `ViewController` instance each time.

The solution was to explicitly `nil` out the references to those functions each time a cell is removed from the screen, as well as cleaning up every single remaining cell when the view controller itself is removed from its parent.

There might be an easier way to do this in Swift (Is there any way to just mark those properties as weak somehow?), and if so, please let me know. :)

/cc @jpsim 
