### PR TITLE
removes artifact from the fine grained notifications version

### DIFF
--- a/RealmTasks iOS/CellPresenter.swift
+++ b/RealmTasks iOS/CellPresenter.swift
@@ -125,7 +125,6 @@ class CellPresenter<Item: Object where Item: CellPresentable> {
             try! item.realm?.write {
                 item.realm!.delete(item)
             }
-            tableView.deleteRowsAtIndexPaths([tableView.indexPathForCell(editingCell)!], withRowAnimation: .None)
         }
 
         viewController.didUpdateList()


### PR DESCRIPTION
there was both tableView.reloadData() and deleteRows(...) happening at the same time and this crashed the app. it's line that remained from the fine grained notification version

this fixes: https://github.com/realm/RealmTasks/issues/229
