### PR TITLE
Don't use a bogus sync server URL when building for Release

### DIFF
--- a/RealmTasks Shared/Constants.swift
+++ b/RealmTasks Shared/Constants.swift
@@ -21,14 +21,10 @@
 import Foundation
 
 struct Constants {
-    #if DEBUG
     #if os(OSX)
     static let syncHost = "127.0.0.1"
     #else
     static let syncHost = localIPAddress
-    #endif
-    #else
-    static let syncHost = "SPECIFY_PRODUCTION_HOST_HERE"
     #endif
 
     static let syncRealmPath = "realmtasks"


### PR DESCRIPTION
This allows builds of the release configuration to connect to the demo server in the same way as debug builds.

I'm not clear why we thought it was a good idea to do something different for release builds. It's possible I'm missing a good reason for this to be the way it is.

/cc @jpsim @stel @TimOliver 
