### PR TITLE
[Android] Remove long press and drag an item feature.

### DIFF
--- a/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TouchHelper.java
+++ b/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TouchHelper.java
@@ -28,7 +28,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.OnItemTouchListener;
 import android.support.v7.widget.RecyclerView.ViewHolder;
-import android.support.v7.widget.helper.ItemTouchHelper;
 import android.util.DisplayMetrics;
 import android.view.GestureDetector.SimpleOnGestureListener;
 import android.view.MotionEvent;


### PR DESCRIPTION
Long-press-and-drag-an-item is not stable. It will encounter several rendering errors and crashes. This PR removes this feature.

Please review this @cmelchior @nhachicha 
