### PR TITLE
Changed Cell Contents Capture Method

### DIFF
--- a/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks iOS/TablePresenter.swift
@@ -133,8 +133,14 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
             destinationIndexPath = indexPath
 
             // Add the snapshot as subview, aligned with the cell
+            var snapshotImage: UIImage
+            UIGraphicsBeginImageContextWithOptions(cell.frame.size, true, 0.0)
+            cell.layer.renderInContext(UIGraphicsGetCurrentContext()!)
+            snapshotImage = UIGraphicsGetImageFromCurrentImageContext()!
+            UIGraphicsEndImageContext()
+            
             var center = cell.center
-            snapshot = cell.snapshotViewAfterScreenUpdates(false)
+            snapshot = UIImageView(image: snapshotImage)
             snapshot.layer.shadowColor = UIColor.blackColor().CGColor
             snapshot.layer.shadowOffset = CGSize(width: -5, height: 0)
             snapshot.layer.shadowRadius = 5

--- a/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks iOS/TablePresenter.swift
@@ -133,14 +133,11 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
             destinationIndexPath = indexPath
 
             // Add the snapshot as subview, aligned with the cell
-            var snapshotImage: UIImage
-            UIGraphicsBeginImageContextWithOptions(cell.frame.size, true, 0.0)
-            cell.layer.renderInContext(UIGraphicsGetCurrentContext()!)
-            snapshotImage = UIGraphicsGetImageFromCurrentImageContext()!
-            UIGraphicsEndImageContext()
-            
             var center = cell.center
-            snapshot = UIImageView(image: snapshotImage)
+            UIGraphicsBeginImageContextWithOptions(cell.frame.size, true, 0)
+            cell.layer.renderInContext(UIGraphicsGetCurrentContext()!)
+            snapshot = UIImageView(image: UIGraphicsGetImageFromCurrentImageContext()!)
+            UIGraphicsEndImageContext()
             snapshot.layer.shadowColor = UIColor.blackColor().CGColor
             snapshot.layer.shadowOffset = CGSize(width: -5, height: 0)
             snapshot.layer.shadowRadius = 5


### PR DESCRIPTION
Fixes: #249

Since calling `UIView.snapshotViewAfterScreenUpdates()` is breaking on certain device configurations in iOS 10, this PR has moved that functionality to the tried-and-true method of using Core Graphics to render the layer contents to a `UIImageView`.

Tested and confirmed to be working on the simulators previously reported to be breaking.

/cc @jpsim @icanzilb @astigsen 