### PR TITLE
[macOS] Enabled '+' button while still editing a cell.

### DIFF
--- a/RealmTasks macOS/TaskListViewController.swift
+++ b/RealmTasks macOS/TaskListViewController.swift
@@ -115,6 +115,11 @@ class TaskListViewController: NSViewController {
 extension TaskListViewController {
 
     @IBAction func newTask(sender: AnyObject?) {
+        if currentlyEditingCellView != nil {
+            currentlyEditingCellView?.window?.makeFirstResponder(nil)
+            return
+        }
+        
         try! items.realm?.write {
             self.items.insert(Task(), atIndex: 0)
         }
@@ -127,15 +132,6 @@ extension TaskListViewController {
             self.view.window?.toolbar?.validateVisibleItems()
         }
     }
-
-    override func validateToolbarItem(theItem: NSToolbarItem) -> Bool {
-        if theItem.action == #selector(newTask) && currentlyEditingCellView != nil {
-            return false
-        }
-
-        return true
-    }
-
 }
 
 // MARK: Reordering

--- a/RealmTasks macOS/TaskListViewController.swift
+++ b/RealmTasks macOS/TaskListViewController.swift
@@ -115,10 +115,8 @@ class TaskListViewController: NSViewController {
 extension TaskListViewController {
 
     @IBAction func newTask(sender: AnyObject?) {
-        if currentlyEditingCellView != nil {
-            currentlyEditingCellView?.window?.makeFirstResponder(nil)
-            return
-        }
+        // Commit any currently editing cells
+        currentlyEditingCellView?.window?.makeFirstResponder(nil)
         
         try! items.realm?.write {
             self.items.insert(Task(), atIndex: 0)

--- a/RealmTasks macOS/TaskListViewController.swift
+++ b/RealmTasks macOS/TaskListViewController.swift
@@ -130,7 +130,7 @@ extension TaskListViewController {
             self.view.window?.toolbar?.validateVisibleItems()
         }
     }
-    
+
     override func validateToolbarItem(theItem: NSToolbarItem) -> Bool {
         if theItem.action == #selector(newTask) && currentlyEditingCellView != nil && currentlyEditingCellView?.text.characters.count == 0 {
             return false
@@ -433,7 +433,7 @@ extension TaskListViewController: TaskCellViewDelegate {
     func cellViewDidChangeText(view: TaskCellView) {
         if view == currentlyEditingCellView {
             updateTableViewHeightOfRows(NSIndexSet(index: tableView.rowForView(view)))
-            self.currentlyEditingCellView?.window?.toolbar?.validateVisibleItems()
+            self.view.window?.toolbar?.validateVisibleItems()
         }
     }
 

--- a/RealmTasks macOS/TaskListViewController.swift
+++ b/RealmTasks macOS/TaskListViewController.swift
@@ -132,6 +132,14 @@ extension TaskListViewController {
             self.view.window?.toolbar?.validateVisibleItems()
         }
     }
+    
+    override func validateToolbarItem(theItem: NSToolbarItem) -> Bool {
+        if theItem.action == #selector(newTask) && currentlyEditingCellView != nil && currentlyEditingCellView?.text.characters.count == 0 {
+            return false
+        }
+
+        return true
+    }
 }
 
 // MARK: Reordering
@@ -427,6 +435,7 @@ extension TaskListViewController: TaskCellViewDelegate {
     func cellViewDidChangeText(view: TaskCellView) {
         if view == currentlyEditingCellView {
             updateTableViewHeightOfRows(NSIndexSet(index: tableView.rowForView(view)))
+            self.currentlyEditingCellView?.window?.toolbar?.validateVisibleItems()
         }
     }
 


### PR DESCRIPTION
Address #290.

When a cell is currently being edited, clicking '+' again will commit the contents of the text field. 
EDIT: If the cell is empty, the '+' button will be disabled.

/cc @stel @astigsen @jpsim 