### PR TITLE
Added layout constraints for content view in placeholder cell

### DIFF
--- a/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks iOS/ViewController.swift
@@ -204,6 +204,13 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             placeHolderCell.right == placeHolderCell.superview!.superview!.right
             placeHolderCell.height == tableView.rowHeight
         }
+        
+        constrain(placeHolderCell, placeHolderCell.contentView) { placeHolderCell, contentView in
+            contentView.top == placeHolderCell.top
+            contentView.left == placeHolderCell.left
+            contentView.bottom == placeHolderCell.bottom
+            contentView.right == placeHolderCell.right
+        }
     }
 
     private func toggleOnboardView(animated animated: Bool = false) {


### PR DESCRIPTION
Fixes #257 + #255.

Apparently in iOS 10, the `contentView` of a given `UITableViewCell` isn't given a default value like in the previous versions, and has initially 0 width. This is presumably updated when the cell is added to a `UITableView` queue, which doesn't happen with the placeholder cell here.

This PR adds auto-layout constraints to the content view of the placeholder cell, fixing the layout issues we were having on iOS 10.

/cc @jpsim 