### PR TITLE
Fix macOS sandboxing while building with package_release.rb

### DIFF
--- a/RealmTasks.xcodeproj/project.pbxproj
+++ b/RealmTasks.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					C23EB01C1D46329400D3E0AC = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 0800;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 1;


### PR DESCRIPTION
related to https://github.com/realm/realm-sync-services/issues/352

It's hard to review `xcodeproj`, but the changes there are:
1. Remove default signing identity from Project settings
2. Add proper signing identities for each target
3. Allow Xcode manage signing identity automatically

Xcode disabled sandboxind during build because of lack of signing identities.
