### PR TITLE
simplify boolean logic in validateToolbarItem

### DIFF
--- a/RealmTasks Apple/RealmTasks macOS/TaskListViewController.swift
+++ b/RealmTasks Apple/RealmTasks macOS/TaskListViewController.swift
@@ -132,11 +132,7 @@ extension TaskListViewController {
     }
 
     override func validateToolbarItem(theItem: NSToolbarItem) -> Bool {
-        if theItem.action == #selector(newTask) && currentlyEditingCellView != nil && currentlyEditingCellView?.text.characters.count == 0 {
-            return false
-        }
-
-        return true
+        return theItem.action != #selector(newTask) || currentlyEditingCellView?.text.isEmpty == false
     }
 }
 


### PR DESCRIPTION
`if X { return true } else { return false }` is an anti-pattern. Introduced in #293 /cc @TimOliver 