### PR TITLE
Second round of code reorg re: #112

### DIFF
--- a/RealmTasks Apple/RealmTasks iOS/ListPresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ListPresenter.swift
@@ -85,4 +85,22 @@ class ListPresenter<Item: Object, Parent: Object where Item: CellPresentable, Pa
             self.viewController.tableView.reloadData()
         }
     }
+
+    // MARK: Onboarding
+    lazy var onboardView: OnboardView = {
+        return OnboardView.add(inView: self.viewController.tableView)
+    }()
+
+    func updateOnboardView(animated: Bool = false) {
+        onboardView.toggle(animated: animated, isVisible: parent.items.isEmpty)
+    }
+
+    func setOnboardAlpha(alpha: CGFloat) {
+        guard parent.items.isEmpty else {
+            updateOnboardView()
+            return
+        }
+        
+        onboardView.alpha = alpha
+    }
 }

--- a/RealmTasks Apple/RealmTasks iOS/ListPresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ListPresenter.swift
@@ -100,7 +100,7 @@ class ListPresenter<Item: Object, Parent: Object where Item: CellPresentable, Pa
             updateOnboardView()
             return
         }
-        
+
         onboardView.alpha = alpha
     }
 }

--- a/RealmTasks Apple/RealmTasks iOS/ListPresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ListPresenter.swift
@@ -96,11 +96,10 @@ class ListPresenter<Item: Object, Parent: Object where Item: CellPresentable, Pa
     }
 
     func setOnboardAlpha(alpha: CGFloat) {
-        guard parent.items.isEmpty else {
+        if parent.items.isEmpty {
+            onboardView.alpha = alpha
+        } else {
             updateOnboardView()
-            return
         }
-
-        onboardView.alpha = alpha
     }
 }

--- a/RealmTasks Apple/RealmTasks iOS/ListPresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ListPresenter.swift
@@ -27,6 +27,8 @@ class ListPresenter<Item: Object, Parent: Object where Item: CellPresentable, Pa
     var cellPresenter: CellPresenter<Item>!
     var tablePresenter: TablePresenter<Parent>!
 
+    private var notificationToken: NotificationToken?
+
     var viewController: ViewControllerProtocol! {
         didSet {
             cellPresenter.viewController = viewController
@@ -37,6 +39,8 @@ class ListPresenter<Item: Object, Parent: Object where Item: CellPresentable, Pa
             } else if observingText {
                 parent.removeObserver(self, forKeyPath: "text")
             }
+
+            notificationToken = setupNotifications()
         }
     }
 
@@ -46,6 +50,10 @@ class ListPresenter<Item: Object, Parent: Object where Item: CellPresentable, Pa
         cellPresenter = CellPresenter(items: parent.items)
         tablePresenter = TablePresenter(parent: parent, colors: colors)
         tablePresenter.cellPresenter = cellPresenter
+    }
+
+    deinit {
+        notificationToken?.stop()
     }
 
     // MARK: List title
@@ -62,6 +70,19 @@ class ListPresenter<Item: Object, Parent: Object where Item: CellPresentable, Pa
     override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         if context == &titleKVOContext {
             viewController.setListTitle((parent as! CellPresentable).text)
+        }
+    }
+
+    // MARK: Notifications
+    private func setupNotifications() -> NotificationToken {
+        return parent.items.addNotificationBlock { [unowned self] changes in
+            // Do not perform an update if the user is editing a cell at this moment
+            // (The table will be reloaded by the 'end editing' call of the active cell)
+            guard self.cellPresenter.currentlyEditingCell == nil else {
+                return
+            }
+
+            self.viewController.tableView.reloadData()
         }
     }
 }

--- a/RealmTasks Apple/RealmTasks iOS/OnboardView.swift
+++ b/RealmTasks Apple/RealmTasks iOS/OnboardView.swift
@@ -27,6 +27,13 @@ class OnboardView: UIView {
     private let imageView = UIImageView(image: UIImage(named: "PullToRefresh")?.imageWithRenderingMode(.AlwaysTemplate))
     private let labelView = UILabel()
 
+    static func add(inView tableView: UITableView) -> OnboardView {
+        let onBoard = OnboardView()
+        tableView.addSubview(onBoard)
+        onBoard.center = tableView.center
+        return onBoard
+    }
+
     init() {
         labelView.text = "Pull Down to Start"
         labelView.font = .systemFontOfSize(20, weight: UIFontWeightMedium)

--- a/RealmTasks Apple/RealmTasks iOS/OnboardView.swift
+++ b/RealmTasks Apple/RealmTasks iOS/OnboardView.swift
@@ -63,4 +63,16 @@ class OnboardView: UIView {
             imageView.top == imageView.superview!.top
         }
     }
+
+    func toggle(animated animated: Bool = false, isVisible: Bool) {
+        func updateAlpha() {
+            alpha = isVisible ? 1 : 0
+        }
+
+        if animated {
+            UIView.animateWithDuration(0.3, animations: updateAlpha)
+        } else {
+            updateAlpha()
+        }
+    }
 }

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -289,7 +289,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     }
 
     // MARK: Placeholder cell
-    func setupPlaceholderCell(inTableView tableView: UITableView) -> TableViewCell<Parent.Item>  {
+    func placeholderCell(inTableView tableView: UITableView) -> TableViewCell<Parent.Item>  {
         let placeHolderCell = TableViewCell<Parent.Item>(style: .Default, reuseIdentifier: "cell")
         placeHolderCell.alpha = 0
         placeHolderCell.backgroundView!.backgroundColor = colorForRow(0)
@@ -308,5 +308,4 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
 
         return placeHolderCell
     }
-
 }

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -40,11 +40,11 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     }
     weak var cellPresenter: CellPresenter<Parent.Item>!
 
-    var items: List<Parent.Item> {
+    private var items: List<Parent.Item> {
         return parent.items
     }
 
-    let parent: Parent
+    private let parent: Parent
     init(parent: Parent, colors: [UIColor]) {
         self.parent = parent
         self.colors = colors
@@ -158,7 +158,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     private var startIndexPath: NSIndexPath?
     private var destinationIndexPath: NSIndexPath?
 
-    func setupMovingGesture() {
+    private func setupMovingGesture() {
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(longPressGestureRecognized(_:)))
         longPressGestureRecognizer.delegate = self
         viewController.tableView.addGestureRecognizer(longPressGestureRecognizer)

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -82,11 +82,10 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     }
 
     override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
-        let tableView = viewController.tableView
-        let tableViewContentView = viewController.tableViewContentView
-        let view = tableView.superview!
-
         if context == &tableViewBoundsKVOContext {
+            let tableView = viewController.tableView
+            let tableViewContentView = viewController.tableViewContentView
+            let view = tableView.superview!
             let height = max(view.frame.height - tableView.contentInset.top, tableView.contentSize.height + tableView.contentInset.bottom)
             tableViewContentView.frame = CGRect(x: 0, y: -tableView.contentOffset.y, width: view.frame.width, height: height)
         } else {

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -38,7 +38,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
             setupMovingGesture()
         }
     }
-    weak var cellPresenter: CellPresenter<Parent.Item>?
+    weak var cellPresenter: CellPresenter<Parent.Item>!
 
     var items: List<Parent.Item> {
         return parent.items
@@ -102,9 +102,6 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
 
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = viewController.tableView.dequeueReusableCellWithIdentifier("cell", forIndexPath: indexPath) as! TableViewCell<Parent.Item>
-        guard let cellPresenter = cellPresenter else {
-            return cell
-        }
 
         cell.item = items[indexPath.row]
         cell.presenter = cellPresenter
@@ -119,10 +116,6 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     // MARK: UITableViewDelegate
 
     func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        guard let cellPresenter = cellPresenter else {
-            return 0.0
-        }
-
         if cellPresenter.currentlyEditingIndexPath?.row == indexPath.row {
             return floor(cellPresenter.cellHeightForText(cellPresenter.currentlyEditingCell!.textView.text))
         }
@@ -143,9 +136,6 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
 
     func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
         cell.contentView.backgroundColor = colorForRow(indexPath.row)
-        guard let cellPresenter = cellPresenter else {
-            return
-        }
         cell.alpha = cellPresenter.currentlyEditing ? editingCellAlpha : 1
     }
 

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -19,6 +19,7 @@
 import Foundation
 import RealmSwift
 import UIKit
+import Cartography
 
 class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     UITableViewDataSource, UITableViewDelegate, UIGestureRecognizerDelegate {
@@ -240,4 +241,26 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
             completion?()
         })
     }
+
+    // MARK: Placeholder cell
+    func setupPlaceholderCell(inTableView tableView: UITableView) -> TableViewCell<Parent.Item>  {
+        let placeHolderCell = TableViewCell<Parent.Item>(style: .Default, reuseIdentifier: "cell")
+        placeHolderCell.alpha = 0
+        placeHolderCell.backgroundView!.backgroundColor = colorForRow(0)
+        placeHolderCell.layer.anchorPoint = CGPoint(x: 0.5, y: 1)
+        tableView.addSubview(placeHolderCell)
+        constrain(placeHolderCell) { placeHolderCell in
+            placeHolderCell.bottom == placeHolderCell.superview!.topMargin - 7 + 26
+            placeHolderCell.left == placeHolderCell.superview!.superview!.left
+            placeHolderCell.right == placeHolderCell.superview!.superview!.right
+            placeHolderCell.height == tableView.rowHeight
+        }
+
+        constrain(placeHolderCell.contentView, placeHolderCell) { contentView, placeHolderCell in
+            contentView.edges == placeHolderCell.edges
+        }
+
+        return placeHolderCell
+    }
+
 }

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -348,7 +348,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
                 placeHolderCell.navHintView.hintText = "Switch to Lists"
                 placeHolderCell.navHintView.hintArrowTransfom = CGAffineTransformRotate(CGAffineTransformIdentity, CGFloat(M_PI))
 
-                UIView.animateWithDuration(0.4, delay: 0.0, usingSpringWithDamping: 1.0, initialSpringVelocity: 0.5,
+                UIView.animateWithDuration(0.4, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0.5,
                     options: [], animations: { [unowned self] in
 
                     self.placeHolderCell.navHintView.alpha = 1

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -144,6 +144,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     }
 
     // MARK: UIScrollViewDelegate
+
     func scrollViewDidScroll(scrollView: UIScrollView) {
         viewController.scrollViewDidScroll?(scrollView)
     }
@@ -153,6 +154,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     }
 
     // MARK: Moving
+
     private var snapshot: UIView!
     private var startIndexPath: NSIndexPath?
     private var destinationIndexPath: NSIndexPath?
@@ -261,6 +263,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     }
 
     // MARK: Colors
+
     private let colors: [UIColor]
 
     func colorForRow(row: Int) -> UIColor {
@@ -309,7 +312,6 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     func adjustPlaceholder(state: PlaceholderState) {
         switch state {
             case .pullToCreate(let distancePulledDown):
-
                 UIView.animateWithDuration(0.1) { [unowned self] in
                     self.placeHolderCell.navHintView.alpha = 0
                 }
@@ -323,17 +325,13 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
                 transform = CATransform3DRotate(transform, angle, 1, 0, 0)
 
                 placeHolderCell.layer.transform = transform
-
             case .releaseToCreate:
-
                 UIView.animateWithDuration(0.1) { [unowned self] in
                     self.placeHolderCell.navHintView.alpha = 0
                 }
                 placeHolderCell.layer.transform = CATransform3DIdentity
                 placeHolderCell.textView.text = "Release to Create Item"
-
             case .switchToLists:
-
                 placeHolderCell.navHintView.hintText = "Switch to Lists"
                 placeHolderCell.navHintView.hintArrowTransfom = CGAffineTransformRotate(CGAffineTransformIdentity, CGFloat(M_PI))
 

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -300,7 +300,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     // Placeholder cell to use before being adding to the table view
     private let placeHolderCell = TableViewCell<Parent.Item>(style: .Default, reuseIdentifier: "cell")
 
-    func setupPlaceholderCell(inTableView tableView: UITableView)  {
+    func setupPlaceholderCell(inTableView tableView: UITableView) {
         placeHolderCell.alpha = 0
         placeHolderCell.backgroundView!.backgroundColor = colorForRow(0)
         placeHolderCell.layer.anchorPoint = CGPoint(x: 0.5, y: 1)
@@ -354,7 +354,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
                     self.placeHolderCell.navHintView.alpha = 1
                     self.placeHolderCell.navHintView.hintArrowTransfom  = CGAffineTransformIdentity
                 }, completion: nil)
-            
+
             case .alpha(let alpha):
                 placeHolderCell.alpha = alpha
         }

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -16,10 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import Cartography
 import Foundation
 import RealmSwift
 import UIKit
-import Cartography
 
 private var tableViewBoundsKVOContext = 0
 

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -21,6 +21,8 @@ import RealmSwift
 import UIKit
 import Cartography
 
+private var tableViewBoundsKVOContext = 0
+
 class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     UITableViewDataSource, UITableViewDelegate, UIGestureRecognizerDelegate {
 
@@ -39,6 +41,50 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
     init(parent: Parent, colors: [UIColor]) {
         self.parent = parent
         self.colors = colors
+    }
+
+    deinit {
+        viewController.tableView.removeObserver(self, forKeyPath: "bounds")
+    }
+
+    // MARK: Setup table view
+
+    func setupTableView(inView view: UIView, inout topConstraint: NSLayoutConstraint?, listTitle title: String?) {
+        let tableView = viewController.tableView
+        let tableViewContentView = viewController.tableViewContentView
+
+        view.addSubview(tableView)
+        constrain(tableView) { tableView in
+            topConstraint = (tableView.top == tableView.superview!.top)
+            tableView.right == tableView.superview!.right
+            tableView.bottom == tableView.superview!.bottom
+            tableView.left == tableView.superview!.left
+        }
+        tableView.registerClass(TableViewCell<Parent.Item>.self, forCellReuseIdentifier: "cell")
+        tableView.separatorStyle = .None
+        tableView.backgroundColor = .blackColor()
+        tableView.rowHeight = 54
+        tableView.contentInset = UIEdgeInsets(top: (title != nil) ? 41 : 20, left: 0, bottom: 54, right: 0)
+        tableView.contentOffset = CGPoint(x: 0, y: -tableView.contentInset.top)
+        tableView.showsVerticalScrollIndicator = false
+
+        view.addSubview(tableViewContentView)
+        tableViewContentView.hidden = true
+
+        tableView.addObserver(self, forKeyPath: "bounds", options: .New, context: &tableViewBoundsKVOContext)
+    }
+
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+        let tableView = viewController.tableView
+        let tableViewContentView = viewController.tableViewContentView
+        let view = tableView.superview!
+
+        if context == &tableViewBoundsKVOContext {
+            let height = max(view.frame.height - tableView.contentInset.top, tableView.contentSize.height + tableView.contentInset.bottom)
+            tableViewContentView.frame = CGRect(x: 0, y: -tableView.contentOffset.y, width: view.frame.width, height: height)
+        } else {
+            super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
+        }
     }
 
     // MARK: UITableViewDataSource

--- a/RealmTasks Apple/RealmTasks iOS/UIView+constraints.swift
+++ b/RealmTasks Apple/RealmTasks iOS/UIView+constraints.swift
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import UIKit
+
+extension UIView {
+    internal func removeAllConstraints() {
+        var view: UIView? = self
+        while let superview = view?.superview {
+            for c in superview.constraints where c.firstItem === self || c.secondItem === self {
+                superview.removeConstraint(c)
+            }
+            view = superview.superview
+        }
+        translatesAutoresizingMaskIntoConstraints = true
+    }
+}

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -36,13 +36,10 @@ extension UIView {
     }
 }
 
-private var tableViewBoundsKVOContext = 0
-
 private enum NavDirection {
     case Up, Down
 }
 
-// MARK: Navigation Protocol
 enum ViewControllerType {
     case Lists
     case DefaultListTasks
@@ -52,22 +49,6 @@ enum ViewControllerType {
 enum ViewControllerPosition {
     case Up(ViewControllerType)
     case Down(ViewControllerType)
-}
-
-// MARK: View Controller Protocol
-protocol ViewControllerProtocol: UIScrollViewDelegate {
-    var tableView: UITableView {get}
-    var tableViewContentView: UIView {get}
-    var view: UIView! {get}
-
-    func didUpdateList()
-
-    func setTopConstraintTo(constant constant: CGFloat)
-    func setPlaceholderAlpha(alpha: CGFloat)
-
-    func setListTitle(title: String)
-
-    func removeFromParentViewController()
 }
 
 // MARK: View Controller
@@ -131,7 +112,6 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
     }
 
     deinit {
-        tableView.removeObserver(self, forKeyPath: "bounds")
         notificationToken?.stop()
     }
 
@@ -150,35 +130,9 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
     }
 
     private func setupTableView() {
-        view.addSubview(tableView)
-        constrain(tableView) { tableView in
-            topConstraint = (tableView.top == tableView.superview!.top)
-            tableView.right == tableView.superview!.right
-            tableView.bottom == tableView.superview!.bottom
-            tableView.left == tableView.superview!.left
-        }
+        listPresenter.tablePresenter.setupTableView(inView: view, topConstraint: &topConstraint, listTitle: title)
         tableView.dataSource = listPresenter.tablePresenter
         tableView.delegate = listPresenter.tablePresenter
-        tableView.registerClass(TableViewCell<Item>.self, forCellReuseIdentifier: "cell")
-        tableView.separatorStyle = .None
-        tableView.backgroundColor = .blackColor()
-        tableView.rowHeight = 54
-        tableView.contentInset = UIEdgeInsets(top: (title != nil) ? 41 : 20, left: 0, bottom: 54, right: 0)
-        tableView.contentOffset = CGPoint(x: 0, y: -tableView.contentInset.top)
-        tableView.showsVerticalScrollIndicator = false
-
-        view.addSubview(tableViewContentView)
-        tableViewContentView.hidden = true
-        tableView.addObserver(self, forKeyPath: "bounds", options: .New, context: &tableViewBoundsKVOContext)
-    }
-
-    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
-        if context == &tableViewBoundsKVOContext {
-            let height = max(view.frame.height - tableView.contentInset.top, tableView.contentSize.height + tableView.contentInset.bottom)
-            tableViewContentView.frame = CGRect(x: 0, y: -tableView.contentOffset.y, width: view.frame.width, height: height)
-        } else {
-            super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
-        }
     }
 
     override func didMoveToParentViewController(parent: UIViewController?) {

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -23,19 +23,6 @@ import Cartography
 import RealmSwift
 import UIKit
 
-extension UIView {
-    private func removeAllConstraints() {
-        var view: UIView? = self
-        while let superview = view?.superview {
-            for c in superview.constraints where c.firstItem === self || c.secondItem === self {
-                superview.removeConstraint(c)
-            }
-            view = superview.superview
-        }
-        translatesAutoresizingMaskIntoConstraints = true
-    }
-}
-
 private enum NavDirection {
     case Up, Down
 }

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -101,7 +101,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
 
         tableView.dataSource = listPresenter.tablePresenter
         tableView.delegate = listPresenter.tablePresenter
-        
+
         listPresenter.updateOnboardView()
     }
 
@@ -244,7 +244,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
                 .adjustPlaceholder(.pullToCreate(distance: distancePulledDown))
 
             listPresenter.setOnboardAlpha(max(0, 1 - (distancePulledDown / cellHeight)))
-            
+
         } else if distancePulledDown <= tableView.rowHeight * 2 {
 
             listPresenter.tablePresenter.adjustPlaceholder(.releaseToCreate)

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -72,7 +72,15 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
     }()
 
     // Onboard view
-    private let onboardView = OnboardView()
+    private lazy var onboardView: OnboardView = {
+        let onboardView = OnboardView()
+        if onboardView.superview == nil {
+            self.tableView.addSubview(onboardView)
+            onboardView.center = self.tableView.center
+        }
+        return onboardView
+    }()
+
 
     // Top/Bottom View Controllers
     private var topViewController: UIViewController?
@@ -105,7 +113,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
 
     private func setupUI() {
         setupTableView()
-        toggleOnboardView()
+        onboardView.toggle(isVisible: items.isEmpty)
     }
 
     private func setupTableView() {
@@ -122,23 +130,6 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
         let visibleCells = tableView.visibleCells
         for cell in visibleCells {
             (cell as! TableViewCell<Item>).reset()
-        }
-    }
-
-    private func toggleOnboardView(animated animated: Bool = false) {
-        if onboardView.superview == nil {
-            tableView.addSubview(onboardView)
-            onboardView.center = tableView.center
-        }
-
-        func updateAlpha() {
-            onboardView.alpha = items.isEmpty ? 1 : 0
-        }
-
-        if animated {
-            UIView.animateWithDuration(0.3, animations: updateAlpha)
-        } else {
-            updateAlpha()
         }
     }
 
@@ -173,7 +164,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             }
             let indexPath = NSIndexPath(forRow: row, inSection: 0)
             tableView.reloadData()
-            toggleOnboardView(animated: true)
+            onboardView.toggle(animated: true, isVisible: items.isEmpty)
             cell = tableView.cellForRowAtIndexPath(indexPath) as! TableViewCell<Item>
         }
         let textView = cell.textView
@@ -353,7 +344,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
     func didUpdateList() {
         listPresenter.tablePresenter.updateColors()
         tableView.reloadData()
-        toggleOnboardView()
+        onboardView.toggle(isVisible: items.isEmpty)
     }
 
     func setTopConstraintTo(constant constant: CGFloat) {

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -16,9 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-// FIXME: This file should be split up.
-// swiftlint:disable file_length
-
 import Cartography
 import RealmSwift
 import UIKit
@@ -40,8 +37,6 @@ enum ViewControllerPosition {
 
 // MARK: View Controller
 
-// FIXME: This class should be split up.
-// swiftlint:disable type_body_length
 final class ViewController<Item: Object, Parent: Object where Item: CellPresentable, Parent: ListPresentable, Parent.Item == Item>:
     UIViewController, UIGestureRecognizerDelegate, UIScrollViewDelegate, ViewControllerProtocol {
 

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -112,14 +112,10 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
     // MARK: UI
 
     private func setupUI() {
-        setupTableView()
-        onboardView.toggle(isVisible: items.isEmpty)
-    }
-
-    private func setupTableView() {
         listPresenter.tablePresenter.setupTableView(inView: view, topConstraint: &topConstraint, listTitle: title)
         tableView.dataSource = listPresenter.tablePresenter
         tableView.delegate = listPresenter.tablePresenter
+        onboardView.toggle(isVisible: items.isEmpty)
     }
 
     override func didMoveToParentViewController(parent: UIViewController?) {

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -51,11 +51,8 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
     }
 
     // Table View
-    let tableView = UITableView()
+    internal let tableView = UITableView()
     internal let tableViewContentView = UIView()
-
-    // Notifications
-    private var notificationToken: NotificationToken?
 
     // Scrolling
     private var distancePulledDown: CGFloat {
@@ -98,14 +95,9 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
         }
     }
 
-    deinit {
-        notificationToken?.stop()
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        setupNotifications()
         setupGestureRecognizers()
     }
 
@@ -147,20 +139,6 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             UIView.animateWithDuration(0.3, animations: updateAlpha)
         } else {
             updateAlpha()
-        }
-    }
-
-    // MARK: Notifications
-
-    private func setupNotifications() {
-        notificationToken = items.addNotificationBlock { [unowned self] changes in
-            // Do not perform an update if the user is editing a cell at this moment
-            // (The table will be reloaded by the 'end editing' call of the active cell)
-            guard self.listPresenter.cellPresenter.currentlyEditingCell == nil else {
-                return
-            }
-
-            self.tableView.reloadData()
         }
     }
 

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -67,9 +67,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
     private var nextConstraints: ConstraintGroup?
 
     // Placeholder cell to use before being adding to the table view
-    private lazy var placeHolderCell: TableViewCell<Item> = {
-        return self.listPresenter.tablePresenter.setupPlaceholderCell(inTableView: self.tableView)
-    }()
+    private var placeHolderCell: TableViewCell<Item>!
 
     // Onboard view
     private lazy var onboardView: OnboardView = {
@@ -107,6 +105,8 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
 
     private func setupUI() {
         listPresenter.tablePresenter.setupTableView(inView: view, topConstraint: &topConstraint, listTitle: title)
+        placeHolderCell = listPresenter.tablePresenter.placeholderCell(inTableView: tableView)
+
         tableView.dataSource = listPresenter.tablePresenter
         tableView.delegate = listPresenter.tablePresenter
         onboardView.toggle(isVisible: items.isEmpty)

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -73,14 +73,8 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
 
     // Onboard view
     private lazy var onboardView: OnboardView = {
-        let onboardView = OnboardView()
-        if onboardView.superview == nil {
-            self.tableView.addSubview(onboardView)
-            onboardView.center = self.tableView.center
-        }
-        return onboardView
+        return OnboardView.add(inView: self.tableView)
     }()
-
 
     // Top/Bottom View Controllers
     private var topViewController: UIViewController?

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -66,11 +66,6 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
     private var topConstraint: NSLayoutConstraint?
     private var nextConstraints: ConstraintGroup?
 
-    // Onboard view
-    private lazy var onboardView: OnboardView = {
-        return OnboardView.add(inView: self.tableView)
-    }()
-
     // Top/Bottom View Controllers
     private var topViewController: UIViewController?
     private var bottomViewController: UIViewController?
@@ -106,7 +101,8 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
 
         tableView.dataSource = listPresenter.tablePresenter
         tableView.delegate = listPresenter.tablePresenter
-        onboardView.toggle(isVisible: items.isEmpty)
+        
+        listPresenter.updateOnboardView()
     }
 
     override func didMoveToParentViewController(parent: UIViewController?) {
@@ -151,7 +147,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             }
             let indexPath = NSIndexPath(forRow: row, inSection: 0)
             tableView.reloadData()
-            onboardView.toggle(animated: true, isVisible: items.isEmpty)
+            listPresenter.updateOnboardView(true)
             cell = tableView.cellForRowAtIndexPath(indexPath) as! TableViewCell<Item>
         }
         let textView = cell.textView
@@ -247,11 +243,8 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             listPresenter.tablePresenter
                 .adjustPlaceholder(.pullToCreate(distance: distancePulledDown))
 
-            if items.isEmpty {
-                onboardView.alpha = max(0, 1 - (distancePulledDown / cellHeight))
-            } else {
-                onboardView.alpha = 0
-            }
+            listPresenter.setOnboardAlpha(max(0, 1 - (distancePulledDown / cellHeight)))
+            
         } else if distancePulledDown <= tableView.rowHeight * 2 {
 
             listPresenter.tablePresenter.adjustPlaceholder(.releaseToCreate)
@@ -313,8 +306,8 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
     // MARK: ViewControllerProtocol
     func didUpdateList() {
         listPresenter.tablePresenter.updateColors()
+        listPresenter.updateOnboardView()
         tableView.reloadData()
-        onboardView.toggle(isVisible: items.isEmpty)
     }
 
     func setTopConstraintTo(constant constant: CGFloat) {

--- a/RealmTasks Apple/RealmTasks iOS/ViewControllerProtocol.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewControllerProtocol.swift
@@ -1,0 +1,35 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import UIKit
+
+// MARK: View Controller Protocol
+protocol ViewControllerProtocol: UIScrollViewDelegate {
+    var tableView: UITableView {get}
+    var tableViewContentView: UIView {get}
+    var view: UIView! {get}
+
+    func didUpdateList()
+
+    func setTopConstraintTo(constant constant: CGFloat)
+    func setPlaceholderAlpha(alpha: CGFloat)
+
+    func setListTitle(title: String)
+
+    func removeFromParentViewController()
+}

--- a/RealmTasks Apple/RealmTasks.xcodeproj/project.pbxproj
+++ b/RealmTasks Apple/RealmTasks.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		9C24AA071D8FEEB500192CE3 /* CellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C24AA061D8FEEB500192CE3 /* CellPresenter.swift */; };
 		9C24AA0B1D8FFC0400192CE3 /* TablePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C24AA0A1D8FFC0400192CE3 /* TablePresenter.swift */; };
 		9C24AA0D1D8FFEA200192CE3 /* ListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C24AA0C1D8FFEA200192CE3 /* ListPresenter.swift */; };
+		9CDF4F1D1D9E73AF00EC051B /* ViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CDF4F1C1D9E73AF00EC051B /* ViewControllerProtocol.swift */; };
 		AF6DB3B195E188C570802C2B /* Pods_RealmTasks_RealmTasks_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C1FC133460B9224E2A98CBE /* Pods_RealmTasks_RealmTasks_macOS.framework */; };
 		C23EB0201D46329400D3E0AC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23EB01F1D46329400D3E0AC /* AppDelegate.swift */; };
 		C23EB0221D46329400D3E0AC /* macOS.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C23EB0211D46329400D3E0AC /* macOS.xcassets */; };
@@ -83,6 +84,7 @@
 		9C24AA0A1D8FFC0400192CE3 /* TablePresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TablePresenter.swift; sourceTree = "<group>"; };
 		9C24AA0C1D8FFEA200192CE3 /* ListPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListPresenter.swift; sourceTree = "<group>"; };
 		9CCE23B978EF7565F4866B4B /* Pods-RealmTasks-RealmTasks iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmTasks-RealmTasks iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RealmTasks-RealmTasks iOS/Pods-RealmTasks-RealmTasks iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		9CDF4F1C1D9E73AF00EC051B /* ViewControllerProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerProtocol.swift; sourceTree = "<group>"; };
 		C23EB01D1D46329400D3E0AC /* RealmTasks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RealmTasks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C23EB01F1D46329400D3E0AC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C23EB0211D46329400D3E0AC /* macOS.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = macOS.xcassets; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				9C24AA0C1D8FFEA200192CE3 /* ListPresenter.swift */,
 				9C24AA061D8FEEB500192CE3 /* CellPresenter.swift */,
 				9C24AA0A1D8FFC0400192CE3 /* TablePresenter.swift */,
+				9CDF4F1C1D9E73AF00EC051B /* ViewControllerProtocol.swift */,
 			);
 			name = ViewController;
 			sourceTree = "<group>";
@@ -649,6 +652,7 @@
 				E8A1E6501D59354500D8B04A /* ContainerViewController.swift in Sources */,
 				9C24AA0D1D8FFEA200192CE3 /* ListPresenter.swift in Sources */,
 				2252019E1D3DD648009E45FA /* AppDelegate.swift in Sources */,
+				9CDF4F1D1D9E73AF00EC051B /* ViewControllerProtocol.swift in Sources */,
 				E89CE68E1D409D3500BB4521 /* LogInViewController.swift in Sources */,
 				E89CE68F1D409D3500BB4521 /* RegisterViewController.swift in Sources */,
 				225201A41D3DD648009E45FA /* Models.swift in Sources */,

--- a/RealmTasks Apple/RealmTasks.xcodeproj/project.pbxproj
+++ b/RealmTasks Apple/RealmTasks.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		9C24AA0B1D8FFC0400192CE3 /* TablePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C24AA0A1D8FFC0400192CE3 /* TablePresenter.swift */; };
 		9C24AA0D1D8FFEA200192CE3 /* ListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C24AA0C1D8FFEA200192CE3 /* ListPresenter.swift */; };
 		9CDF4F1D1D9E73AF00EC051B /* ViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CDF4F1C1D9E73AF00EC051B /* ViewControllerProtocol.swift */; };
+		9CDF4F1F1D9E745300EC051B /* UIView+constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CDF4F1E1D9E745300EC051B /* UIView+constraints.swift */; };
 		AF6DB3B195E188C570802C2B /* Pods_RealmTasks_RealmTasks_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C1FC133460B9224E2A98CBE /* Pods_RealmTasks_RealmTasks_macOS.framework */; };
 		C23EB0201D46329400D3E0AC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23EB01F1D46329400D3E0AC /* AppDelegate.swift */; };
 		C23EB0221D46329400D3E0AC /* macOS.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C23EB0211D46329400D3E0AC /* macOS.xcassets */; };
@@ -85,6 +86,7 @@
 		9C24AA0C1D8FFEA200192CE3 /* ListPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListPresenter.swift; sourceTree = "<group>"; };
 		9CCE23B978EF7565F4866B4B /* Pods-RealmTasks-RealmTasks iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmTasks-RealmTasks iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RealmTasks-RealmTasks iOS/Pods-RealmTasks-RealmTasks iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		9CDF4F1C1D9E73AF00EC051B /* ViewControllerProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerProtocol.swift; sourceTree = "<group>"; };
+		9CDF4F1E1D9E745300EC051B /* UIView+constraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+constraints.swift"; sourceTree = "<group>"; };
 		C23EB01D1D46329400D3E0AC /* RealmTasks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RealmTasks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C23EB01F1D46329400D3E0AC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C23EB0211D46329400D3E0AC /* macOS.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = macOS.xcassets; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 				22092D851D5C5BCB0016E757 /* NavHintView.swift */,
 				2252019A1D3DD648009E45FA /* TableViewCell.swift */,
 				2252019D1D3DD648009E45FA /* ViewController.swift */,
+				9CDF4F1E1D9E745300EC051B /* UIView+constraints.swift */,
 				9C24AA031D8FED0800192CE3 /* ViewController */,
 			);
 			path = "RealmTasks iOS";
@@ -651,6 +654,7 @@
 				225201A31D3DD648009E45FA /* TableViewCell.swift in Sources */,
 				E8A1E6501D59354500D8B04A /* ContainerViewController.swift in Sources */,
 				9C24AA0D1D8FFEA200192CE3 /* ListPresenter.swift in Sources */,
+				9CDF4F1F1D9E745300EC051B /* UIView+constraints.swift in Sources */,
 				2252019E1D3DD648009E45FA /* AppDelegate.swift in Sources */,
 				9CDF4F1D1D9E73AF00EC051B /* ViewControllerProtocol.swift in Sources */,
 				E89CE68E1D409D3500BB4521 /* LogInViewController.swift in Sources */,

--- a/RealmTasks Apple/RealmTasks.xcodeproj/project.pbxproj
+++ b/RealmTasks Apple/RealmTasks.xcodeproj/project.pbxproj
@@ -162,19 +162,14 @@
 		225201931D3DD648009E45FA /* RealmTasks iOS */ = {
 			isa = PBXGroup;
 			children = (
+				9CDF4F201D9E780100EC051B /* Views */,
 				22FEFEBB1D91789B00523E21 /* RealmTasks.entitlements */,
 				225201941D3DD648009E45FA /* AppDelegate.swift */,
-				2252019C1D3DD648009E45FA /* CellTextView.swift */,
-				E8A1E64F1D59354500D8B04A /* ContainerViewController.swift */,
 				225201981D3DD648009E45FA /* Info.plist */,
 				225201951D3DD648009E45FA /* iOS.xcassets */,
 				225201961D3DD648009E45FA /* LaunchScreen.storyboard */,
+				E8A1E64F1D59354500D8B04A /* ContainerViewController.swift */,
 				E89CE6821D409D0400BB4521 /* LogInViewController */,
-				220C33491D3DE1F40043A885 /* OnboardView.swift */,
-				22092D851D5C5BCB0016E757 /* NavHintView.swift */,
-				2252019A1D3DD648009E45FA /* TableViewCell.swift */,
-				2252019D1D3DD648009E45FA /* ViewController.swift */,
-				9CDF4F1E1D9E745300EC051B /* UIView+constraints.swift */,
 				9C24AA031D8FED0800192CE3 /* ViewController */,
 			);
 			path = "RealmTasks iOS";
@@ -183,12 +178,25 @@
 		9C24AA031D8FED0800192CE3 /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				2252019D1D3DD648009E45FA /* ViewController.swift */,
 				9C24AA0C1D8FFEA200192CE3 /* ListPresenter.swift */,
 				9C24AA061D8FEEB500192CE3 /* CellPresenter.swift */,
 				9C24AA0A1D8FFC0400192CE3 /* TablePresenter.swift */,
 				9CDF4F1C1D9E73AF00EC051B /* ViewControllerProtocol.swift */,
 			);
 			name = ViewController;
+			sourceTree = "<group>";
+		};
+		9CDF4F201D9E780100EC051B /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				220C33491D3DE1F40043A885 /* OnboardView.swift */,
+				2252019C1D3DD648009E45FA /* CellTextView.swift */,
+				2252019A1D3DD648009E45FA /* TableViewCell.swift */,
+				22092D851D5C5BCB0016E757 /* NavHintView.swift */,
+				9CDF4F1E1D9E745300EC051B /* UIView+constraints.swift */,
+			);
+			name = Views;
 			sourceTree = "<group>";
 		};
 		C23EB01E1D46329400D3E0AC /* RealmTasks macOS */ = {


### PR DESCRIPTION
This PR should not change any functionality it only restructures the code to lighten the load on ViewController:

moves as much as possible view logic out of view controller into respective files
simplifies navigation and avoids the usage of closures to create controllers
reorders iOS project files into groups to improve discoverability
I looked into fully extracting the navigation out of ViewController as discussed in #112 but I ran into weird racing problems when ViewController objects are created from another class during table view scrolling and after a while, it felt more practical to wrap up all other changes and send a PR