### PR TITLE
Fix toolbar validation & cells dragging in Mac app

### DIFF
--- a/RealmTasks Apple/RealmTasks macOS/TaskCellView.swift
+++ b/RealmTasks Apple/RealmTasks macOS/TaskCellView.swift
@@ -229,17 +229,13 @@ extension TaskCellView: TaskTextFieldDelegate {
 extension TaskCellView: NSGestureRecognizerDelegate {
 
     func gestureRecognizerShouldBegin(gestureRecognizer: NSGestureRecognizer) -> Bool {
-        guard gestureRecognizer is NSPanGestureRecognizer else {
-            return false
-        }
-
         let currentlyEditingTextField = ((window?.firstResponder as? NSText)?.delegate as? NSTextField)
 
-        guard let event = NSApp.currentEvent where currentlyEditingTextField != textView else {
+        guard currentlyEditingTextField != textView else {
             return false
         }
 
-        return fabs(event.deltaX) > fabs(event.deltaY)
+        return true
     }
 
     // FIXME: This could easily be refactored to avoid such a high CC.

--- a/RealmTasks Apple/RealmTasks macOS/TaskListViewController.swift
+++ b/RealmTasks Apple/RealmTasks macOS/TaskListViewController.swift
@@ -132,7 +132,7 @@ extension TaskListViewController {
     }
 
     override func validateToolbarItem(theItem: NSToolbarItem) -> Bool {
-        return theItem.action != #selector(newTask) || currentlyEditingCellView?.text.isEmpty == false
+        return theItem.action != #selector(newTask) || currentlyEditingCellView == nil || currentlyEditingCellView?.text.isEmpty == false
     }
 }
 


### PR DESCRIPTION
`NSApp.currentEvent` doesn't contain `deltaX` anymore in `gestureRecognizerShouldBegin` on Sierra, so this should fix cells dragging. 

/cc @radu-tutueanu, @jpsim 