### PR TITLE
[Android] update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is in no way a fully feature-complete product, nor is it ever meant to be an 
 
 **Android**
 
-* Android Studio 2.2 with Android API 24 
+* Android Studio 2.2 with Android API 25
 * An emulator, Genymotion or or a real device attached and running.
 
 

--- a/RealmTasks Android/app/build.gradle
+++ b/RealmTasks Android/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'realm-android'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         applicationId "io.realm.realmtasks"
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -32,7 +32,7 @@ android {
 
     signingConfigs {
         config {
-            storeFile file("${projectDir}/../keystore/debug.keystore")
+            storeFile rootProject.file("keystore/debug.keystore")
             storePassword "android"
             keyAlias "androiddebugkey"
             keyPassword "android"
@@ -53,17 +53,15 @@ realm {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.0'
-    compile 'com.android.support:design:24.2.0'
-    compile 'com.android.support:support-annotations:24.2.0'
-    compile('io.realm:android-adapters:1.3.0') {
-        exclude group: "io.realm"
-    }
+    compile 'com.android.support:appcompat-v7:25.0.0'
+    compile 'com.android.support:design:25.0.0'
+    compile 'com.android.support:support-annotations:25.0.0'
+    compile 'io.realm:android-adapters:1.4.0'
     // Dependency for Facebook Sign-in
     compile 'com.facebook.android:facebook-android-sdk:4.15.0'
 
     // Dependency for Google Sign-In
-    compile 'com.google.android.gms:play-services-auth:9.6.1'
+    compile 'com.google.android.gms:play-services-auth:9.8.0'
 }
 
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
@realm/java 

realm-android-adapters: 1.3.0 to 1.4.0
compileSdkVersion and targetSdkVersion: 24 to 25
support libraries: 24.2.0 to 25.0.0
google play services: 9.6.1 to 9.8.0