### PR TITLE
set Android, iOS and macOS app versions to 0.2.2

### DIFF
--- a/RealmTasks Android/app/build.gradle
+++ b/RealmTasks Android/app/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 24
         versionCode 1
-        versionName "1.0"
+        versionName "0.2.2"
     }
     buildTypes {
         def host = InetAddress.getLocalHost().getCanonicalHostName()

--- a/RealmTasks Apple/RealmTasks iOS/Info.plist
+++ b/RealmTasks Apple/RealmTasks iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RealmTasks Apple/RealmTasks macOS/Info.plist
+++ b/RealmTasks Apple/RealmTasks macOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
[v0.2.2](https://github.com/realm/RealmTasks/releases/tag/v0.2.2) was released earlier today, but so far, the apps in this repo have all been versioned as "1.0".

Am I doing this right on the Android side, or should `versionCode` also be bumped @zaki50?