### PR TITLE
[macOS, iOS] Log out on sync auth error

### DIFF
--- a/RealmTasks Apple/RealmTasks iOS/AppDelegate.swift
+++ b/RealmTasks Apple/RealmTasks iOS/AppDelegate.swift
@@ -24,6 +24,13 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         window = UIWindow(frame: UIScreen.mainScreen().bounds)
+
+        setAuthenticationFailureCallback {
+            resetDefaultRealm()
+            self.window?.rootViewController = UIViewController()
+            self.logIn()
+        }
+
         if configureDefaultRealm() {
             window?.rootViewController = ContainerViewController()
             window?.makeKeyAndVisible()

--- a/RealmTasks Apple/RealmTasks macOS/AppDelegate.swift
+++ b/RealmTasks Apple/RealmTasks macOS/AppDelegate.swift
@@ -41,6 +41,32 @@ class AppDelegate: NSObject {
         mainWindowController.contentViewController?.presentViewControllerAsSheet(registerViewController, preventApplicationTermination: false)
     }
 
+    @IBAction func logOut(sender: AnyObject? = nil) {
+        guard isDefaultRealmConfigured() else {
+            return
+        }
+
+        let containerViewController = mainWindowController.contentViewController as! ContainerViewController
+        containerViewController.dismissAllViewControllers()
+
+        resetDefaultRealm()
+
+        logIn()
+    }
+
+    private func performAuthentication(viewController: NSViewController, username: String, password: String, register: Bool) {
+        authenticate(username: username, password: password, register: register) { error in
+            if let error = error {
+                NSApp.presentError(error)
+            } else {
+                viewController.dismissController(nil)
+
+                let containerViewController = self.mainWindowController.contentViewController as! ContainerViewController
+                containerViewController.showRecentList(nil)
+            }
+        }
+    }
+
 }
 
 extension AppDelegate: NSApplicationDelegate {
@@ -49,6 +75,10 @@ extension AppDelegate: NSApplicationDelegate {
         mainWindowController = mainStoryboard.instantiateControllerWithIdentifier("MainWindowController") as! NSWindowController
         mainWindowController.window?.titleVisibility = .Hidden
         mainWindowController.showWindow(nil)
+
+        setAuthenticationFailureCallback {
+            self.logOut()
+        }
 
         if configureDefaultRealm() {
             let containerViewController = mainWindowController.contentViewController as! ContainerViewController
@@ -64,24 +94,6 @@ extension AppDelegate: NSApplicationDelegate {
         return true
     }
 
-}
-
-extension AppDelegate {
-    func performAuthentication(viewController: NSViewController, username: String, password: String, register: Bool) {
-        authenticate(username: username, password: password, register: register) { error in
-            // FIXME: Sync API methods callbacks should be executed on main thread
-            dispatch_async(dispatch_get_main_queue()) {
-                if let error = error {
-                    NSApp.presentError(error)
-                } else {
-                    viewController.dismissController(nil)
-
-                    let containerViewController = self.mainWindowController.contentViewController as! ContainerViewController
-                    containerViewController.showRecentList(nil)
-                }
-            }
-        }
-    }
 }
 
 extension AppDelegate: LogInViewControllerDelegate {

--- a/RealmTasks Apple/RealmTasks macOS/ContainerViewController.swift
+++ b/RealmTasks Apple/RealmTasks macOS/ContainerViewController.swift
@@ -121,6 +121,21 @@ class ContainerViewController: NSViewController {
         }
     }
 
+    func dismissAllViewControllers() {
+        currentListViewController?.removeFromParentViewController()
+        currentListViewController?.view.removeFromSuperview()
+        currentListViewController = nil
+
+        notificationToken?.stop()
+        notificationToken = nil
+
+        if let titleView = view.window?.toolbar?.itemWithIdentifier(toolbarTitleViewIdentifier)?.view as? TitleView {
+            titleView.text = ""
+        }
+
+        view.window?.makeFirstResponder(nil)
+    }
+
     private func updateToolbarForList<ListType: ListPresentable where ListType: Object>(list: ListType) {
         guard let toolbar = view.window?.toolbar else {
             return

--- a/RealmTasks Apple/RealmTasks macOS/Main.storyboard
+++ b/RealmTasks Apple/RealmTasks macOS/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
     </dependencies>
@@ -63,54 +63,17 @@
                                                 <action selector="newItem:" target="VaM-de-JXt" id="OtT-Tp-uOI"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Open…" keyEquivalent="o" id="m6V-zC-Op3">
-                                            <connections>
-                                                <action selector="openDocument:" target="VaM-de-JXt" id="Mpd-F7-ENn"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Open Recent" id="QRB-rg-HEz">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="lcN-MU-lGm">
-                                                <items>
-                                                    <menuItem title="Clear Menu" id="SVT-Rk-Tv8">
-                                                        <connections>
-                                                            <action selector="clearRecentDocuments:" target="VaM-de-JXt" id="H6U-SX-wa4"/>
-                                                        </connections>
-                                                    </menuItem>
-                                                </items>
-                                            </menu>
-                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="MeL-WZ-xZR"/>
                                         <menuItem title="Close" keyEquivalent="w" id="crh-aF-s4Y">
                                             <connections>
                                                 <action selector="performClose:" target="VaM-de-JXt" id="OmX-WS-gqe"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Save" keyEquivalent="s" id="QTK-5X-N14">
-                                            <connections>
-                                                <action selector="saveDocument:" target="VaM-de-JXt" id="XYy-Kr-7og"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Save As…" keyEquivalent="S" id="pd8-CG-g8Z">
-                                            <connections>
-                                                <action selector="saveDocumentAs:" target="VaM-de-JXt" id="Wqc-gI-q32"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Revert to Saved" id="fD5-wP-iuL">
+                                        <menuItem isSeparatorItem="YES" id="hAe-88-VzD"/>
+                                        <menuItem title="Log Out" id="nxD-Om-Bap">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="revertDocumentToSaved:" target="VaM-de-JXt" id="0Hm-eg-cB8"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem isSeparatorItem="YES" id="hAe-88-VzD"/>
-                                        <menuItem title="Page Setup…" keyEquivalent="P" id="YUb-eY-KbF">
-                                            <connections>
-                                                <action selector="runPageLayout:" target="VaM-de-JXt" id="Ffz-fP-DGR"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Print…" keyEquivalent="p" id="nxD-Om-Bap">
-                                            <connections>
-                                                <action selector="print:" target="VaM-de-JXt" id="Rfz-oe-iPR"/>
+                                                <action selector="logOut:" target="VaM-de-JXt" id="yv9-pY-Qac"/>
                                             </connections>
                                         </menuItem>
                                     </items>
@@ -381,7 +344,7 @@
         <scene sceneID="Eh9-Oq-vpp">
             <objects>
                 <windowController storyboardIdentifier="MainWindowController" showSeguePresentationStyle="single" id="CrP-T3-Pfk" sceneMemberID="viewController">
-                    <window key="window" title="RealmTasks" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="UPX-nY-FVZ">
+                    <window key="window" title="RealmTasks" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="UPX-nY-FVZ">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" unifiedTitleAndToolbar="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>


### PR DESCRIPTION
This PR adds "Log out" menu item to macOS app and triggers logging out if sync session is not created or invalidated so there is no reason to remove the app from iOS device and reset macOS app when resetting the server anymore.

fixes #205 

/cc @jpsim, @TimOliver, @radu-tutueanu 
