### PR TITLE
Integrate Fine-Grained Notifications in iOS app

### DIFF
--- a/RealmTasks Apple/Podfile
+++ b/RealmTasks Apple/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 abstract_target 'RealmTasks' do
     use_frameworks!
     
-    pod 'RealmSwift', '~> 2.0.0'
+    pod 'RealmSwift', '~> 2.1.0'
     
     pod 'Cartography', '~> 0.7'
     

--- a/RealmTasks Apple/Podfile.lock
+++ b/RealmTasks Apple/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
   - Cartography (0.7.0)
-  - Realm (2.0.4):
-    - Realm/Headers (= 2.0.4)
-  - Realm/Headers (2.0.4)
-  - RealmSwift (2.0.4):
-    - Realm (= 2.0.4)
+  - Realm (2.1.0):
+    - Realm/Headers (= 2.1.0)
+  - Realm/Headers (2.1.0)
+  - RealmSwift (2.1.0):
+    - Realm (= 2.1.0)
 
 DEPENDENCIES:
   - Cartography (~> 0.7)
-  - RealmSwift (~> 2.0.0)
+  - RealmSwift (~> 2.1.0)
 
 SPEC CHECKSUMS:
   Cartography: dd6044b6fe352252f68b648df5bff47841e591cc
-  Realm: 9da97f48365f8b99dd95c28d45ad8222d62e1775
-  RealmSwift: 01e8db006035f16003e6307ae8eae1adccce68db
+  Realm: bc829ad0ef3d4eea70c34cfcc3b1704d18d50df1
+  RealmSwift: a4d4abbf0088c337cab5b738054395842e4b3052
 
-PODFILE CHECKSUM: 007502a7f55269351f27a640f5e79dd23b82a196
+PODFILE CHECKSUM: 60481898c7d0afa0783625490d7c26082dff8331
 
 COCOAPODS: 1.1.1

--- a/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
+++ b/RealmTasks Apple/RealmTasks iOS/TablePresenter.swift
@@ -205,11 +205,10 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
         case .Changed:
             snapshot.center.y = location.y
 
-            if let destinationIndexPath = destinationIndexPath where indexPath != destinationIndexPath && !items[indexPath.row].completed {
+            if let destinationPath = destinationIndexPath where indexPath != destinationPath && !items[indexPath.row].completed {
                 // move rows
-                tableView.moveRowAtIndexPath(destinationIndexPath, toIndexPath: indexPath)
-
-                self.destinationIndexPath = indexPath
+                tableView.moveRowAtIndexPath(destinationPath, toIndexPath: indexPath)
+                destinationIndexPath = indexPath
             }
         case .Ended, .Cancelled, .Failed:
             guard
@@ -219,7 +218,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
                 else { break }
 
             if destinationIndexPath.row != startIndexPath.row && !items[destinationIndexPath.row].completed {
-                try! items.realm?.write {
+                viewController.uiWriteNoUpdateList {
                     items.move(from: startIndexPath.row, to: destinationIndexPath.row)
                 }
             }
@@ -239,9 +238,7 @@ class TablePresenter<Parent: Object where Parent: ListPresentable>: NSObject,
                 self.snapshot.removeFromSuperview()
                 self.snapshot = nil
 
-                self.updateColors {
-                    UIView.performWithoutAnimation(tableView.reloadData)
-                }
+                self.viewController.didUpdateList(reload: false)
             })
 
             self.startIndexPath = nil

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -160,10 +160,10 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             items.realm?.beginWrite()
             let row = items.filter("completed = false").count
             items.insert(Item(), atIndex: row)
-            try! items.realm?.commitWrite(withoutNotifying: [listPresenter.notificationToken!])
             let indexPath = NSIndexPath(forRow: row, inSection: 0)
             tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             cell = tableView.cellForRowAtIndexPath(indexPath) as! TableViewCell<Item>
+            finishUIWrite()
             listPresenter.updateOnboardView(true)
         }
         let textView = cell.textView
@@ -298,7 +298,7 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
                     return NSIndexPath(forRow: index, inSection: 0)
                 }
                 tableView.deleteRowsAtIndexPaths(indexPathsToDelete, withRowAnimation: .Automatic)
-                try! items.realm?.commitWrite(withoutNotifying: [listPresenter.notificationToken!])
+                finishUIWrite()
                 vibrate()
             }
             return
@@ -312,10 +312,10 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             return
         }
         // Create new item
-        uiWriteNoUpdateList {
+        uiWrite {
             items.insert(Item(), atIndex: 0)
         }
-        didUpdateList(reload: true)
+        tableView.reloadData()
         if let firstCell = tableView.visibleCells.first as? TableViewCell<Item> {
             firstCell.textView.becomeFirstResponder()
         }

--- a/RealmTasks Apple/RealmTasks iOS/ViewController.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewController.swift
@@ -67,6 +67,28 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
 
     private var listPresenter: ListPresenter<Item, Parent>!
 
+    // MARK: UI Writes
+
+    func uiWrite(@noescape block: () -> ()) {
+        uiWriteNoUpdateList(block)
+        didUpdateList(reload: false)
+    }
+
+    func uiWriteNoUpdateList(@noescape block: () -> ()) {
+        items.realm?.beginWrite()
+        block()
+        commitUIWrite()
+    }
+
+    func finishUIWrite() {
+        commitUIWrite()
+        didUpdateList(reload: false)
+    }
+
+    private func commitUIWrite() {
+        _ = try? items.realm?.commitWrite(withoutNotifying: [listPresenter.notificationToken!])
+    }
+
     // MARK: View Lifecycle
 
     init(parent: Parent, colors: [UIColor]) {
@@ -135,15 +157,14 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
                 return
             }
         } else {
-            var row: Int = 0
-            try! items.realm?.write {
-                row = items.filter("completed = false").count
-                items.insert(Item(), atIndex: row)
-            }
+            items.realm?.beginWrite()
+            let row = items.filter("completed = false").count
+            items.insert(Item(), atIndex: row)
+            try! items.realm?.commitWrite(withoutNotifying: [listPresenter.notificationToken!])
             let indexPath = NSIndexPath(forRow: row, inSection: 0)
-            tableView.reloadData()
-            listPresenter.updateOnboardView(true)
+            tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             cell = tableView.cellForRowAtIndexPath(indexPath) as! TableViewCell<Item>
+            listPresenter.updateOnboardView(true)
         }
         let textView = cell.textView
         textView.userInteractionEnabled = !textView.userInteractionEnabled
@@ -234,16 +255,11 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
         let cellHeight = tableView.rowHeight
 
         if distancePulledDown <= tableView.rowHeight {
-
             listPresenter.tablePresenter
                 .adjustPlaceholder(.pullToCreate(distance: distancePulledDown))
-
             listPresenter.setOnboardAlpha(max(0, 1 - (distancePulledDown / cellHeight)))
-
         } else if distancePulledDown <= tableView.rowHeight * 2 {
-
             listPresenter.tablePresenter.adjustPlaceholder(.releaseToCreate)
-
         } else if case .Up(_) = auxViewController! {
             if topViewController === parentViewController?.childViewControllers.last { return }
             if topViewController == nil {
@@ -267,15 +283,23 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             if bottomViewController === parentViewController?.childViewControllers.last {
                 finishMovingToNextViewController(.Down)
             } else {
-                try! items.realm?.write {
-                    let itemsToDelete = items.filter("completed = true")
-                    let numberOfItemsToDelete = itemsToDelete.count
-                    guard numberOfItemsToDelete != 0 else { return }
-
-                    items.realm?.delete(itemsToDelete)
-
-                    vibrate()
+                items.realm?.beginWrite()
+                let itemsToDelete = items.filter("completed = true")
+                let numberOfItemsToDelete = itemsToDelete.count
+                guard numberOfItemsToDelete != 0 else {
+                    items.realm?.cancelWrite()
+                    return
                 }
+
+                items.realm?.delete(itemsToDelete)
+
+                let startingIndex = items.count
+                let indexPathsToDelete = (startingIndex..<(startingIndex + numberOfItemsToDelete)).map { index in
+                    return NSIndexPath(forRow: index, inSection: 0)
+                }
+                tableView.deleteRowsAtIndexPaths(indexPathsToDelete, withRowAnimation: .Automatic)
+                try! items.realm?.commitWrite(withoutNotifying: [listPresenter.notificationToken!])
+                vibrate()
             }
             return
         }
@@ -288,21 +312,21 @@ final class ViewController<Item: Object, Parent: Object where Item: CellPresenta
             return
         }
         // Create new item
-        try! items.realm?.write {
+        uiWriteNoUpdateList {
             items.insert(Item(), atIndex: 0)
         }
-        tableView.reloadData()
-
+        didUpdateList(reload: true)
         if let firstCell = tableView.visibleCells.first as? TableViewCell<Item> {
             firstCell.textView.becomeFirstResponder()
         }
     }
 
     // MARK: ViewControllerProtocol
-    func didUpdateList() {
+
+    func didUpdateList(reload reload: Bool) {
         listPresenter.tablePresenter.updateColors()
         listPresenter.updateOnboardView()
-        tableView.reloadData()
+        if reload { tableView.reloadData() }
     }
 
     func setTopConstraintTo(constant constant: CGFloat) {

--- a/RealmTasks Apple/RealmTasks iOS/ViewControllerProtocol.swift
+++ b/RealmTasks Apple/RealmTasks iOS/ViewControllerProtocol.swift
@@ -24,7 +24,7 @@ protocol ViewControllerProtocol: UIScrollViewDelegate {
     var tableViewContentView: UIView {get}
     var view: UIView! {get}
 
-    func didUpdateList()
+    func didUpdateList(reload reload: Bool)
 
     func setTopConstraintTo(constant constant: CGFloat)
     func setPlaceholderAlpha(alpha: CGFloat)
@@ -32,4 +32,8 @@ protocol ViewControllerProtocol: UIScrollViewDelegate {
     func setListTitle(title: String)
 
     func removeFromParentViewController()
+
+    func uiWrite(@noescape block: () -> ())
+    func uiWriteNoUpdateList(@noescape block: () -> ())
+    func finishUIWrite()
 }


### PR DESCRIPTION
Don't merge until realm/realm-cocoa#4253 is released. Otherwise ready for review.

This really improves the look and feel of the iOS app, for both local and synchronized changes.

If you're looking to help, this could definitely use more QA testing, although after a few rounds of bug fixes, I wasn't able to crash the app in any conflicting scenario I could come up with.

One notable functional change I made to simplify things is to keep a write transaction open for the duration of editing a cell. This blocks a large number of complex state changes that could modify the UI coming in from sync that would require quite a bit more complexity in the app to be resilient against.

Porting the macOS app to use changeset notifications is turning out to be a bit more involved, so I'll keep that for another PR.

/cc @TimOliver @tgoyne @stel 