### PR TITLE
Integrate Fine-Grained Notifications in macOS app

### DIFF
--- a/RealmTasks Apple/RealmTasks macOS/ItemCellView.swift
+++ b/RealmTasks Apple/RealmTasks macOS/ItemCellView.swift
@@ -273,6 +273,8 @@ extension ItemCellView: ItemTextFieldDelegate {
 
     // Called when esc key was pressesed
     override func cancelOperation(sender: AnyObject?) {
+        textView.abortEditing()
+
         if editable {
             editable = false
             delegate?.cellViewDidEndEditing(self)

--- a/RealmTasks Apple/RealmTasks macOS/ListViewController.swift
+++ b/RealmTasks Apple/RealmTasks macOS/ListViewController.swift
@@ -159,7 +159,7 @@ final class ListViewController<ListType: ListPresentable where ListType: Object>
     @IBAction func newItem(sender: AnyObject?) {
         endEditingCells()
 
-        uiWrite() {
+        uiWrite {
             list.items.insert(ItemType(), atIndex: 0)
         }
 
@@ -216,7 +216,7 @@ final class ListViewController<ListType: ListPresentable where ListType: Object>
         currentlyMovingRowSnapshotView?.frame.origin.y = view.convertPoint(point, fromView: nil).y - currentlyMovingRowSnapshotView!.frame.height / 2
         view.addSubview(currentlyMovingRowSnapshotView!)
 
-        NSView.animate() {
+        NSView.animate {
             let frame = currentlyMovingRowSnapshotView!.frame
             currentlyMovingRowSnapshotView!.frame = frame.insetBy(dx: -frame.width * 0.02, dy: -frame.height * 0.02)
         }
@@ -249,7 +249,7 @@ final class ListViewController<ListType: ListPresentable where ListType: Object>
         if canMoveRow(sourceRow, toRow: destinationRow) {
             list.items.move(from: sourceRow, to: destinationRow)
 
-            NSView.animate() {
+            NSView.animate {
                 // Disable implicit animations because tableView animates reordering via animator proxy
                 NSAnimationContext.currentContext().allowsImplicitAnimation = false
                 tableView.moveRowAtIndex(sourceRow, toIndex: destinationRow)
@@ -526,7 +526,7 @@ final class ListViewController<ListType: ListPresentable where ListType: Object>
         tableView.enumerateAvailableRowViewsUsingBlock { rowView, row in
             // For some reason tableView.viewAtColumn:row: returns nil while animating, will use view hierarchy instead
             if let cellView = rowView.subviews.first as? ItemCellView {
-                NSView.animate() {
+                NSView.animate {
                     cellView.backgroundColor = colorForRow(row)
                 }
             }
@@ -561,7 +561,7 @@ final class ListViewController<ListType: ListPresentable where ListType: Object>
         }
 
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(0.1 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()) {
-            self.uiWrite() {
+            self.uiWrite {
                 item.completed = complete
 
                 if index != destinationIndex {
@@ -584,11 +584,11 @@ final class ListViewController<ListType: ListPresentable where ListType: Object>
             return
         }
 
-        uiWrite() {
+        uiWrite {
             list.realm?.delete(item)
         }
 
-        NSView.animate() {
+        NSView.animate {
             NSAnimationContext.currentContext().allowsImplicitAnimation = false
             tableView.removeRowsAtIndexes(NSIndexSet(index: index), withAnimation: .SlideLeft)
         }

--- a/RealmTasks Apple/RealmTasks macOS/ListViewController.swift
+++ b/RealmTasks Apple/RealmTasks macOS/ListViewController.swift
@@ -374,16 +374,11 @@ final class ListViewController<ListType: ListPresentable where ListType: Object>
 
         var item = list.items[index]
 
-        if cellView.text != item.text || cellView.text.isEmpty {
-            if !cellView.text.isEmpty {
-                item.text = cellView.text
-            } else {
-                item.realm!.delete(item)
-
-                dispatch_async(dispatch_get_main_queue()) {
-                    self.tableView.removeRowsAtIndexes(NSIndexSet(index: index), withAnimation: .SlideUp)
-                }
-            }
+        if cellView.text.isEmpty {
+            item.realm!.delete(item)
+            tableView.removeRowsAtIndexes(NSIndexSet(index: index), withAnimation: .SlideUp)
+        } else if cellView.text != item.text {
+            item.text = cellView.text
         }
 
         currentlyEditingCellView = nil


### PR DESCRIPTION
Related to #352. Enables fine-grained notifications and supports ui writes without notifications. Uses the same trick with open write transaction as in #352, also fixes https://github.com/realm/RealmTasks/issues/208

/cc @jpsim, @TimOliver 