### PR TITLE
RealmTasks Xamarin - fixes error with missing assembly "RealmTasks" on iOS

### DIFF
--- a/RealmTasks Xamarin/RealmTasks.sln
+++ b/RealmTasks Xamarin/RealmTasks.sln
@@ -26,17 +26,11 @@ Global
 		{319878C6-4DA6-438A-9B6D-1C3525B1B2AC}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{319878C6-4DA6-438A-9B6D-1C3525B1B2AC}.Debug|iPhone.Build.0 = Debug|iPhone
 		{319878C6-4DA6-438A-9B6D-1C3525B1B2AC}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
-		{319878C6-4DA6-438A-9B6D-1C3525B1B2AC}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
 		{319878C6-4DA6-438A-9B6D-1C3525B1B2AC}.Release|Any CPU.ActiveCfg = Release|iPhone
-		{319878C6-4DA6-438A-9B6D-1C3525B1B2AC}.Release|Any CPU.Build.0 = Release|iPhone
 		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Release|iPhone.Build.0 = Release|Any CPU
 		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0DA2E72-263F-417B-A76C-06D35BB3B195}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/RealmTasks Xamarin/iOS/RealmTasks.iOS.csproj
+++ b/RealmTasks Xamarin/iOS/RealmTasks.iOS.csproj
@@ -7,7 +7,7 @@
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
     <RootNamespace>RealmTasks.iOS</RootNamespace>
-    <AssemblyName>RealmTasks.iOS</AssemblyName>
+    <AssemblyName>RealmTasks</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
@@ -29,7 +29,6 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
-    <AssemblyName>RealmTasks</AssemblyName>
     <CodesignEntitlements></CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
@@ -63,7 +62,6 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
-    <AssemblyName>RealmTasks</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Also fixed configuration mappings so menu to select config/device shows correct settings