### PR TITLE
Fixed attributed string style value

### DIFF
--- a/RealmTasks Apple/RealmTasks Shared/NSAttributedString+Strikethrough.swift
+++ b/RealmTasks Apple/RealmTasks Shared/NSAttributedString+Strikethrough.swift
@@ -38,7 +38,7 @@ extension NSAttributedString {
         let attributeName = NSStrikethroughStyleAttributeName
         let fullRange = NSRange(0..<length)
         mutableAttributedString.removeAttribute(attributeName, range: fullRange)
-        mutableAttributedString.addAttribute(attributeName, value: style, range: range ?? fullRange)
+        mutableAttributedString.addAttribute(attributeName, value: style.rawValue, range: range ?? fullRange)
 
         return mutableAttributedString
     }


### PR DESCRIPTION
In the Swift 3 refactor, the `rawValue` value of the attributed string style enum was accidentally omitted. This resulted in the text failing to render. 

![img_6096](https://cloud.githubusercontent.com/assets/429119/21922043/20b6ec1e-d9a7-11e6-8033-300931043b65.PNG)
